### PR TITLE
Fix mutable global constant in regex parser

### DIFF
--- a/src/main/kotlin/cacophony/regex/RegexParser.kt
+++ b/src/main/kotlin/cacophony/regex/RegexParser.kt
@@ -11,7 +11,7 @@ fun parseRegex(str: String): AlgebraicRegex {
         val c = regex[it]
         if (specialCharacter) {
             val specialRegex =
-                SPECIAL_CHARACTER_MAP[c]
+                getSpecialCharacterRegex(c)
                     ?: throw RegexSyntaxErrorException("Invalid escaped character '$c' at position ${it - 1}")
             if (it > 1 && (regex[it - 2] !in "(|" || lastEscaped == it - 2)) parser.pushOperation(ConcatOperator)
             parser.pushRegex(specialRegex)
@@ -132,8 +132,12 @@ private data object UnionOperator : InfixOperator(1) {
     ) = if (x is Union) {
         x.summands.add(y)
         x
+    } else if (y is Union) {
+        // Does not need to be at 0, but this is more consistent with string representation.
+        y.summands.add(0, x)
+        y
     } else {
-        Union(arrayListOf(x, y))
+        Union(mutableListOf(x, y))
     }
 }
 
@@ -144,7 +148,10 @@ private data object ConcatOperator : InfixOperator(2) {
     ) = if (x is Concat) {
         x.factors.add(y)
         x
+    } else if (y is Concat) {
+        y.factors.add(0, x)
+        y
     } else {
-        Concat(arrayListOf(x, y))
+        Concat(mutableListOf(x, y))
     }
 }

--- a/src/test/kotlin/cacophony/regex/RegexParserTest.kt
+++ b/src/test/kotlin/cacophony/regex/RegexParserTest.kt
@@ -111,7 +111,7 @@ class RegexParserTest {
         val result = parseRegex("""abc|x(a|b)|x*(ab*)""")
         val s0 = ConcatenationRegex(*"""abc""".map { AtomicRegex(it) }.toTypedArray())
         val s1 = ConcatenationRegex(AtomicRegex('x'), UnionRegex(AtomicRegex('a'), AtomicRegex('b')))
-        val s2 = ConcatenationRegex(StarRegex(AtomicRegex('x')), ConcatenationRegex(AtomicRegex('a'), StarRegex(AtomicRegex('b'))))
+        val s2 = ConcatenationRegex(StarRegex(AtomicRegex('x')), AtomicRegex('a'), StarRegex(AtomicRegex('b')))
         val expected: AlgebraicRegex = UnionRegex(s0, s1, s2)
         assertEqualAlgebraicRegex(result, expected)
     }
@@ -121,7 +121,7 @@ class RegexParserTest {
         val result = parseRegex("""(((a))((b))(c)|(x)(((((a))))|(((b))))|(((x)))*((a)(((b)))*))""")
         val s0 = ConcatenationRegex(*"""abc""".map { AtomicRegex(it) }.toTypedArray())
         val s1 = ConcatenationRegex(AtomicRegex('x'), UnionRegex(AtomicRegex('a'), AtomicRegex('b')))
-        val s2 = ConcatenationRegex(StarRegex(AtomicRegex('x')), ConcatenationRegex(AtomicRegex('a'), StarRegex(AtomicRegex('b'))))
+        val s2 = ConcatenationRegex(StarRegex(AtomicRegex('x')), AtomicRegex('a'), StarRegex(AtomicRegex('b')))
         val expected: AlgebraicRegex = UnionRegex(s0, s1, s2)
         assertEqualAlgebraicRegex(result, expected)
     }
@@ -208,7 +208,7 @@ class RegexParserTest {
     fun `whitespace group special character`() {
         val regex = """\s"""
         val result = parseRegex(regex)
-        val expected = SPECIAL_CHARACTER_MAP['s']!!.toAlgebraicRegex()
+        val expected = getSpecialCharacterRegex('s')!!.toAlgebraicRegex()
         assertEqualAlgebraicRegex(result, expected)
     }
 
@@ -229,7 +229,7 @@ class RegexParserTest {
     @Test
     fun `not-newline special character`() {
         val result = parseRegex("""\N""")
-        val expected = SPECIAL_CHARACTER_MAP['N']!!.toAlgebraicRegex()
+        val expected = getSpecialCharacterRegex('N')!!.toAlgebraicRegex()
         assertEqualAlgebraicRegex(result, expected)
     }
 
@@ -243,7 +243,8 @@ class RegexParserTest {
                 ConcatenationRegex(
                     UnionRegex(
                         AtomicRegex('a'),
-                        UnionRegex(AtomicRegex('a'), AtomicRegex('b')),
+                        AtomicRegex('a'),
+                        AtomicRegex('b'),
                         ConcatenationRegex(AtomicRegex('a'), StarRegex(AtomicRegex('a'))),
                     ),
                     AtomicRegex('x'),


### PR DESCRIPTION

Values of `SPECIAL_CHARACTER_MAP` could be modified. Now they are cloned when needed.