### PR TITLE
Split literals into ints and bools

### DIFF
--- a/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
@@ -51,7 +51,8 @@ enum class CacophonyGrammarSymbol {
     OPERATOR_LOGICAL_NOT,
 
     // and the others
-    LITERAL,
+    INT_LITERAL,
+    BOOL_LITERAL,
     TYPE_IDENTIFIER,
     VARIABLE_IDENTIFIER,
     WHITESPACE,

--- a/src/main/kotlin/cacophony/regex/RegexStrings.kt
+++ b/src/main/kotlin/cacophony/regex/RegexStrings.kt
@@ -60,7 +60,8 @@ object RegexStrings {
             TokenCategorySpecific.OPERATOR_LOGICAL_AND to """&&""",
             TokenCategorySpecific.OPERATOR_LOGICAL_NOT to """!""",
             // and the others
-            TokenCategorySpecific.LITERAL to """-\d(\d)*|\d(\d)*|true|false""",
+            TokenCategorySpecific.INT_LITERAL to """-\d(\d)*|\d(\d)*""",
+            TokenCategorySpecific.BOOL_LITERAL to """true|false""",
             TokenCategorySpecific.TYPE_IDENTIFIER to """\u\w*""",
             TokenCategorySpecific.VARIABLE_IDENTIFIER to """(\l|_)\w*""",
             TokenCategorySpecific.WHITESPACE to """(\n|\r|\t| )*""",

--- a/src/main/kotlin/cacophony/token/TokenCategorySpecific.kt
+++ b/src/main/kotlin/cacophony/token/TokenCategorySpecific.kt
@@ -45,7 +45,8 @@ enum class TokenCategorySpecific {
     OPERATOR_LOGICAL_NOT,
 
     // and the others
-    LITERAL,
+    INT_LITERAL,
+    BOOL_LITERAL,
     TYPE_IDENTIFIER,
     VARIABLE_IDENTIFIER,
     WHITESPACE,


### PR DESCRIPTION
Apparently, no internal lexer changes are currently needed