### PR TITLE
Remove short-circuiting operators from CFGNode

### DIFF
--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -112,16 +112,6 @@ sealed interface CFGNode {
         val value: CFGNode,
     ) : LogicalOperator
 
-    sealed class LogicalAnd(
-        val lhs: CFGNode,
-        val rhs: CFGNode,
-    ) : LogicalOperator
-
-    sealed class LogicalOr(
-        val lhs: CFGNode,
-        val rhs: CFGNode,
-    ) : LogicalOperator
-
     sealed class Equals(
         val lhs: CFGNode,
         val rhs: CFGNode,


### PR DESCRIPTION
These should not be used to allow implementing of short-circuiting