### PR TITLE
Introduce static links

### DIFF
--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -70,6 +70,11 @@ sealed interface CFGNode {
     ) : Unconditional,
         LValue
 
+    class MemoryWrite(
+        val destination: MemoryAccess,
+        val value: CFGNode
+    ): Unconditional
+
     class Constant(
         val value: Int,
     ) : Unconditional,

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -38,115 +38,115 @@ sealed interface CFGNode {
 
     sealed interface LValue : CFGNode
 
-    class Return :
+    data object Return :
         Unconditional,
         Leaf
 
-    class Call(
+    data class Call(
         val declaration: Definition.FunctionDeclaration,
     ) : Unconditional,
         Leaf
 
     // NOTE: Push may be unnecessary since it can be done via Assignment + MemoryAccess
-    class Push(
+    data class Push(
         val value: CFGNode,
     ) : Unconditional
 
     // NOTE: Pop may be unnecessary since it can be done via Assignment
-    class Pop(
+    data class Pop(
         val regvar: Register,
     ) : Unconditional,
         Leaf
 
-    class Assignment(
+    data class Assignment(
         val destination: Register,
         val value: CFGNode,
     ) : Unconditional
 
-    class VariableUse(
+    data class VariableUse(
         val regvar: Register,
     ) : Unconditional,
         Leaf,
         LValue
 
-    class MemoryAccess(
+    data class MemoryAccess(
         val destination: CFGNode,
     ) : Unconditional,
         LValue
 
-    class MemoryWrite(
+    data class MemoryWrite(
         val destination: MemoryAccess,
         val value: CFGNode,
     ) : Unconditional
 
-    class Constant(
+    data class Constant(
         val value: Int,
     ) : Unconditional,
         Leaf
 
-    class Sequence(
+    data class Sequence(
         val nodes: List<CFGNode>,
     ) : Unconditional
 
     sealed interface ArithmeticOperator : Unconditional
 
-    class Addition(
+    data class Addition(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : ArithmeticOperator
 
-    class Subtraction(
+    data class Subtraction(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : ArithmeticOperator
 
-    class Multiplication(
+    data class Multiplication(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : ArithmeticOperator
 
-    class Division(
+    data class Division(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : ArithmeticOperator
 
-    class Modulo(
+    data class Modulo(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : ArithmeticOperator
 
     sealed interface LogicalOperator : CFGNode
 
-    class LogicalNot(
+    data class LogicalNot(
         val value: CFGNode,
     ) : LogicalOperator
 
-    class Equals(
+    data class Equals(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator
 
-    class NotEquals(
+    data class NotEquals(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator
 
-    class Less(
+    data class Less(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator
 
-    class Greater(
+    data class Greater(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator
 
-    class LessEqual(
+    data class LessEqual(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator
 
-    class GreaterEqual(
+    data class GreaterEqual(
         val lhs: CFGNode,
         val rhs: CFGNode,
     ) : LogicalOperator

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -72,8 +72,8 @@ sealed interface CFGNode {
 
     class MemoryWrite(
         val destination: MemoryAccess,
-        val value: CFGNode
-    ): Unconditional
+        val value: CFGNode,
+    ) : Unconditional
 
     class Constant(
         val value: Int,

--- a/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
@@ -43,7 +43,7 @@ class FunctionHandlerImpl(
     private val function: FunctionDeclaration,
     private val analyzedFunction: AnalyzedFunction,
     // List of parents' handlers ordered from immediate parent.
-    private val ancestorFunctionHandlers: List<FunctionHandler>
+    private val ancestorFunctionHandlers: List<FunctionHandler>,
 ) : FunctionHandler {
     private val staticLink: Variable.AuxVariable.StaticLinkVariable = Variable.AuxVariable.StaticLinkVariable()
 
@@ -70,21 +70,21 @@ class FunctionHandlerImpl(
         result: Register?,
     ): CFGFragment {
         val nodes: MutableList<CFGNode> = mutableListOf()
-        if(ancestorFunctionHandlers.isNotEmpty()) {
+        if (ancestorFunctionHandlers.isNotEmpty()) {
             val parentFunction = ancestorFunctionHandlers[0]
             val parentLink = parentFunction.getStaticLink()
             nodes.add(
                 CFGNode.MemoryWrite(
                     CFGNode.MemoryAccess(caller.generateVariableAccess(parentLink)),
-                    CFGNode.MemoryAccess(this.generateVariableAccess(parentLink))
-                )
+                    CFGNode.MemoryAccess(this.generateVariableAccess(parentLink)),
+                ),
             )
         }
         nodes.add(
             CFGNode.MemoryWrite(
                 CFGNode.MemoryAccess(generateVariableAccess(staticLink)),
-                CFGNode.VariableUse(Register.FixedRegister("RBP"))
-            )
+                CFGNode.VariableUse(Register.FixedRegister("RBP")),
+            ),
         )
 
         nodes.addAll(generateCall(arguments, result))

--- a/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
@@ -20,11 +20,19 @@ interface FunctionHandler {
     fun generateCall(
         arguments: List<CFGNode>,
         result: Register?,
+    ): List<CFGNode>
+
+    fun generateCallFrom(
+        function: FunctionHandler,
+        arguments: List<CFGNode>,
+        result: Register?,
     ): CFGFragment
 
     fun generateVariableAccess(variable: Variable): CFGNode
 
     fun getVariableAllocation(variable: Variable): VariableAllocation
+
+    fun getStaticLink(): Variable.AuxVariable.StaticLinkVariable
 }
 
 class GenerateVariableAccessException(
@@ -34,14 +42,53 @@ class GenerateVariableAccessException(
 class FunctionHandlerImpl(
     private val function: FunctionDeclaration,
     private val analyzedFunction: AnalyzedFunction,
+    // List of parents' handlers ordered from immediate parent.
+    private val ancestorFunctionHandlers: List<FunctionHandler>
 ) : FunctionHandler {
+    private val staticLink: Variable.AuxVariable.StaticLinkVariable = Variable.AuxVariable.StaticLinkVariable()
+
     override fun getFunctionDeclaration(): FunctionDeclaration = function
 
     override fun generateCall(
         arguments: List<CFGNode>,
         result: Register?,
-    ): CFGFragment {
+    ): List<CFGNode> {
         TODO("Not yet implemented")
+    }
+
+    // Wrapper for generateCall that additionally fills staticLink to parent function.
+    // Generally when we call another function we have to pass the staticLink to it,
+    // we have to find parent of called function and use variableAccess to its staticLink variable.
+    // It should be possible both from the parent itself and from nested functions,
+    // therefore there is option that both will have this staticLink,
+    // or it can be ified in such a way that calling nested functions uses RBP directly.
+    // I've decided to keep both links (to itself and to parent) in auxVariables.
+    // If it causes problems it can be modified to store only staticLink to parent.
+    override fun generateCallFrom(
+        caller: FunctionHandler,
+        arguments: List<CFGNode>,
+        result: Register?,
+    ): CFGFragment {
+        val nodes: MutableList<CFGNode> = mutableListOf()
+        if(ancestorFunctionHandlers.isNotEmpty()) {
+            val parentFunction = ancestorFunctionHandlers[0]
+            val parentLink = parentFunction.getStaticLink()
+            nodes.add(
+                CFGNode.MemoryWrite(
+                    CFGNode.MemoryAccess(caller.generateVariableAccess(parentLink)),
+                    CFGNode.MemoryAccess(this.generateVariableAccess(parentLink))
+                )
+            )
+        }
+        nodes.add(
+            CFGNode.MemoryWrite(
+                CFGNode.MemoryAccess(generateVariableAccess(staticLink)),
+                CFGNode.VariableUse(Register.FixedRegister("RBP"))
+            )
+        )
+
+        nodes.addAll(generateCall(arguments, result))
+        return mapOf(CFGLabel() to CFGVertex.Final(CFGNode.Sequence(nodes)))
     }
 
     override fun generateVariableAccess(variable: Variable): CFGNode {
@@ -52,7 +99,15 @@ class FunctionHandlerImpl(
         TODO("Not yet implemented")
     }
 
-    private fun introduceStaticLinksParams(): List<CFGNode> {
-        TODO("Not yet implemented")
+    override fun getStaticLink(): Variable.AuxVariable.StaticLinkVariable {
+        return staticLink
+    }
+
+    // Creates staticLink auxVariable in analyzedFunction, therefore shouldn't be called multiple times.
+    private fun introduceStaticLinksParams() {
+        analyzedFunction.auxVariables.add(staticLink)
+        if (ancestorFunctionHandlers.isNotEmpty()) {
+            analyzedFunction.auxVariables.add(ancestorFunctionHandlers[0].getStaticLink())
+        }
     }
 }

--- a/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
@@ -32,7 +32,7 @@ interface FunctionHandler {
 
     fun getVariableAllocation(variable: Variable): VariableAllocation
 
-    //Returns static link to parent
+    // Returns static link to parent
     fun getStaticLink(): Variable.AuxVariable.StaticLinkVariable
 }
 
@@ -46,8 +46,8 @@ class FunctionHandlerImpl(
     // List of parents' handlers ordered from immediate parent.
     private val ancestorFunctionHandlers: List<FunctionHandler>,
 ) : FunctionHandler {
-
     private val staticLink: Variable.AuxVariable.StaticLinkVariable = Variable.AuxVariable.StaticLinkVariable()
+
     init {
         introduceStaticLinksParams()
     }
@@ -78,7 +78,7 @@ class FunctionHandlerImpl(
                 CFGNode.MemoryWrite(
                     CFGNode.MemoryAccess(staticLinkAccess),
                     CFGNode.VariableUse(Register.FixedRegister("RBP")),
-                )
+                ),
             )
         } else {
             // It's called from nested function, therefore caller should have access to staticLink.
@@ -86,7 +86,7 @@ class FunctionHandlerImpl(
                 CFGNode.MemoryWrite(
                     CFGNode.MemoryAccess(staticLinkAccess),
                     callerFunction.generateVariableAccess(staticLink),
-                )
+                ),
             )
         }
 

--- a/src/main/kotlin/cacophony/controlflow/Variable.kt
+++ b/src/main/kotlin/cacophony/controlflow/Variable.kt
@@ -3,7 +3,9 @@ package cacophony.controlflow
 sealed class Variable {
     class SourceVariable : Variable()
 
-    class AuxVariable : Variable()
+    sealed class AuxVariable : Variable() {
+        class StaticLinkVariable() : AuxVariable()
+    }
 }
 
 sealed class Register {

--- a/src/main/kotlin/cacophony/controlflow/Variable.kt
+++ b/src/main/kotlin/cacophony/controlflow/Variable.kt
@@ -3,17 +3,19 @@ package cacophony.controlflow
 import cacophony.semantic.syntaxtree.Definition
 
 sealed class Variable {
-    class SourceVariable(val definition: Definition) : Variable()
+    class SourceVariable(
+        val definition: Definition,
+    ) : Variable()
 
     sealed class AuxVariable : Variable() {
-        class StaticLinkVariable() : AuxVariable()
+        class StaticLinkVariable : AuxVariable()
     }
 }
 
 sealed class Register {
     class VirtualRegister : Register()
 
-    class FixedRegister(
+    data class FixedRegister(
         val hardwareRegister: X64Register,
     ) : Register()
 }

--- a/src/main/kotlin/cacophony/semantic/FunctionAnalysis.kt
+++ b/src/main/kotlin/cacophony/semantic/FunctionAnalysis.kt
@@ -1,5 +1,6 @@
 package cacophony.semantic
 
+import cacophony.controlflow.Variable
 import cacophony.semantic.syntaxtree.AST
 import cacophony.semantic.syntaxtree.Definition
 import cacophony.utils.getReachableFrom
@@ -15,6 +16,7 @@ data class ParentLink(
 data class AnalyzedFunction(
     val parentLink: ParentLink?,
     val variables: Set<AnalyzedVariable>,
+    val auxVariables: MutableSet<Variable.AuxVariable>,
     val staticDepth: Int,
     val variablesUsedInNestedFunctions: Set<Definition>,
 )
@@ -84,7 +86,7 @@ fun makeAnalyzedFunction(
     val variables =
         analyzedVariables[function]
             ?: throw IllegalStateException("Analyzed function is missing variable information")
-    return AnalyzedFunction(parentLink, variables, staticRelations.staticDepth, variablesUsedInNestedFunctions)
+    return AnalyzedFunction(parentLink, variables, mutableSetOf(), staticRelations.staticDepth, variablesUsedInNestedFunctions)
 }
 
 fun makeAnalyzedVariable(

--- a/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
@@ -213,71 +213,76 @@ class FunctionHandlerTest {
             assertThat(getArgumentRegisters(getCallNodes(args, null, false))).isEqualTo(expected)
         }
 
-        // TODO: Uncomment these tests after #122 is merged
-//        @Test
-//        fun `function calling child`() {
-//            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
-//            val childHandler = handlers[0]
-//            val parentHandler = handlers[1]
-//
-//            val staticLinkNode = childHandler.generateCallFrom(
-//                parentHandler,
-//                emptyList(),
-//                null,
-//            )[0]
-//
-//            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
-//            val staticLinkAccess = childHandler.generateVariableAccess(childHandler.getStaticLink())
-//            val expected = CFGNode.MemoryWrite(
-//                CFGNode.MemoryAccess(staticLinkAccess),
-//                CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
-//            )
-//
-//            assertThat(staticLinkNode).isEqualTo(expected)
-//        }
-//
-//        @Test
-//        fun `function calling itself works`() {
-//            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
-//            val childHandler = handlers[0]
-//
-//            val staticLinkNode = childHandler.generateCallFrom(
-//                childHandler,
-//                emptyList(),
-//                null,
-//            )[0]
-//
-//            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
-//            val staticLinkAccess = childHandler.generateVariableAccess(childHandler.getStaticLink())
-//            val expected = CFGNode.MemoryWrite(
-//                CFGNode.MemoryAccess(staticLinkAccess),
-//                childHandler.generateVariableAccess(childHandler.getStaticLink()),
-//            )
-//
-//            assertThat(staticLinkNode).isEqualTo(expected)
-//        }
-//
-//        @Test
-//        fun `function calling parent works`() {
-//            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
-//            val childHandler = handlers[0]
-//            val parentHandler = handlers[1]
-//
-//            val staticLinkNode = parentHandler.generateCallFrom(
-//                childHandler,
-//                emptyList(),
-//                null,
-//            )[0]
-//
-//            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
-//            val staticLinkAccess = childHandler.generateVariableAccess(parentHandler.getStaticLink())
-//            val expected = CFGNode.MemoryWrite(
-//                CFGNode.MemoryAccess(staticLinkAccess),
-//                childHandler.generateVariableAccess(parentHandler.getStaticLink()),
-//            )
-//
-//            assertThat(staticLinkNode).isEqualTo(expected)
-//        }
+        @Test
+        fun `function calling child`() {
+            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
+            val childHandler = handlers[0]
+            val parentHandler = handlers[1]
+
+            val staticLinkNode =
+                childHandler.generateCallFrom(
+                    parentHandler,
+                    emptyList(),
+                    null,
+                )[0]
+
+            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
+            val staticLinkAccess = childHandler.generateVariableAccess(childHandler.getStaticLink())
+            val expected =
+                CFGNode.MemoryWrite(
+                    CFGNode.MemoryAccess(staticLinkAccess),
+                    CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
+                )
+
+            assertThat(staticLinkNode).isEqualTo(expected)
+        }
+
+        @Test
+        fun `function calling itself works`() {
+            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
+            val childHandler = handlers[0]
+
+            val staticLinkNode =
+                childHandler.generateCallFrom(
+                    childHandler,
+                    emptyList(),
+                    null,
+                )[0]
+
+            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
+            val staticLinkAccess = childHandler.generateVariableAccess(childHandler.getStaticLink())
+            val expected =
+                CFGNode.MemoryWrite(
+                    CFGNode.MemoryAccess(staticLinkAccess),
+                    childHandler.generateVariableAccess(childHandler.getStaticLink()),
+                )
+
+            assertThat(staticLinkNode).isEqualTo(expected)
+        }
+
+        @Test
+        fun `function calling parent works`() {
+            val handlers = mockFunDeclarationAndFunHandlerWithParents(0, 3)
+            val childHandler = handlers[0]
+            val parentHandler = handlers[1]
+
+            val staticLinkNode =
+                parentHandler.generateCallFrom(
+                    childHandler,
+                    emptyList(),
+                    null,
+                )[0]
+
+            // This test isn't too interesting, it's more about checking if nothing fails rather if it returns particular value.
+            val staticLinkAccess = childHandler.generateVariableAccess(parentHandler.getStaticLink())
+            val expected =
+                CFGNode.MemoryWrite(
+                    CFGNode.MemoryAccess(staticLinkAccess),
+                    childHandler.generateVariableAccess(parentHandler.getStaticLink()),
+                )
+
+            assertThat(staticLinkNode).isEqualTo(expected)
+        }
     }
 
     @Test

--- a/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
@@ -2,7 +2,10 @@ package cacophony.controlflow
 
 import cacophony.semantic.AnalyzedFunction
 import cacophony.semantic.AnalyzedVariable
-import cacophony.semantic.syntaxtree.Definition
+import cacophony.semantic.ParentLink
+import cacophony.semantic.VariableUseType
+import cacophony.semantic.syntaxtree.*
+import cacophony.utils.Location
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +18,8 @@ import org.junit.jupiter.params.provider.ValueSource
 import kotlin.math.max
 
 class FunctionHandlerTest {
+    val mockRange = Location(0) to Location(0)
+
     @Nested
     inner class GenerateCall {
         private fun mockAnalyzedFunction(): AnalyzedFunction =
@@ -63,13 +68,12 @@ class FunctionHandlerTest {
             argumentCount: Int,
             result: Register?,
             alignStack: Boolean,
-        ): List<CFGNode> {
-            return mockFunDeclarationAndFunHandler(argumentCount).generateCall(
+        ): List<CFGNode> =
+            mockFunDeclarationAndFunHandler(argumentCount).generateCall(
                 (1..argumentCount).map { mockk() },
                 result,
                 alignStack,
             )
-        }
 
         private fun getArgumentRegisters(callNodes: List<CFGNode>): List<X64Register> {
             val returnList = mutableListOf<X64Register>()
@@ -84,9 +88,7 @@ class FunctionHandlerTest {
             return returnList
         }
 
-        private fun getPushCount(callNodes: List<CFGNode>): Int {
-            return callNodes.filterIsInstance<CFGNode.Push>().size
-        }
+        private fun getPushCount(callNodes: List<CFGNode>): Int = callNodes.filterIsInstance<CFGNode.Push>().size
 
         private fun getResultDestination(callNodes: List<CFGNode>): Register? {
             var register: Register? = null
@@ -114,7 +116,8 @@ class FunctionHandlerTest {
                     if (node.value is CFGNode.Addition) {
                         val lhs = (node.value as CFGNode.Addition).lhs
                         val rhs = (node.value as CFGNode.Addition).rhs
-                        if (lhs !is CFGNode.VariableUse || lhs.regvar !is Register.FixedRegister ||
+                        if (lhs !is CFGNode.VariableUse ||
+                            lhs.regvar !is Register.FixedRegister ||
                             (lhs.regvar as Register.FixedRegister).hardwareRegister != X64Register.RSP
                         ) {
                             continue
@@ -381,5 +384,393 @@ class FunctionHandlerTest {
         assertEquals(0, allocation1.offset)
         assert(allocation2.register is Register.VirtualRegister)
         assertEquals(8, allocation3.offset)
+    }
+
+    @Test
+    fun `returns correct function declaration`() {
+        // given
+        val fDef =
+            Definition.FunctionDeclaration(
+                mockRange,
+                "f",
+                null,
+                listOf(),
+                Type.Basic(mockRange, "Int"),
+                Empty(mockRange),
+            )
+        val fAnalyzed =
+            AnalyzedFunction(
+                null,
+                setOf(),
+                mutableSetOf(),
+                0,
+                setOf(),
+            )
+        val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf())
+
+        // when
+        val declaration = fHandler.getFunctionDeclaration()
+
+        // then
+        assertThat(declaration).isEqualTo(fDef)
+    }
+
+    @Nested
+    inner class GenerateVariableAccess {
+        @Test
+        fun `generates variable access to its own source variable allocated in a register`() {
+            // let f = [] -> Int => (
+            //     let x = 10; #allocated in virtual register
+            //     x #variable access
+            // )
+
+            // given
+            val xDef = Definition.VariableDeclaration(mockRange, "x", null, Literal.IntLiteral(mockRange, 10))
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Block(
+                        mockRange,
+                        listOf(
+                            xDef,
+                            VariableUse(mockRange, "x"),
+                        ),
+                    ),
+                )
+            val xAnalyzed = AnalyzedVariable(xDef, fDef, VariableUseType.READ_WRITE)
+            val fAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(xAnalyzed),
+                    mutableSetOf(),
+                    0,
+                    setOf(),
+                )
+            val xAllocation = Register.VirtualRegister()
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf())
+            val x = fHandler.getVariableFromDefinition(xDef)
+            fHandler.registerVariableAllocation(
+                x,
+                VariableAllocation.InRegister(xAllocation),
+            )
+
+            // when
+            val xAccess = fHandler.generateVariableAccess(x)
+
+            // then
+            assertThat(xAccess).isEqualTo(CFGNode.VariableUse(xAllocation))
+        }
+
+        @Test
+        fun `generates variable access to its own source variable allocated on stack`() {
+            // let f = [] -> Int => (
+            //     let x: Int = 10; #allocated on stack
+            //     x #variable access
+            // )
+
+            // given
+            val xDef = Definition.VariableDeclaration(mockRange, "x", null, Literal.IntLiteral(mockRange, 10))
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Block(
+                        mockRange,
+                        listOf(
+                            xDef,
+                            VariableUse(mockRange, "x"),
+                        ),
+                    ),
+                )
+            val xAnalyzed = AnalyzedVariable(xDef, fDef, VariableUseType.READ_WRITE)
+            val fAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(xAnalyzed),
+                    mutableSetOf(),
+                    0,
+                    setOf(),
+                )
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf())
+            val x = fHandler.getVariableFromDefinition(xDef)
+            fHandler.registerVariableAllocation(
+                x,
+                VariableAllocation.OnStack(24),
+            )
+
+            // when
+            val xAccess = fHandler.generateVariableAccess(x)
+
+            // then
+            assertThat(xAccess).isEqualTo(
+                CFGNode.MemoryAccess( // [rbp + 24]
+                    CFGNode.Addition(
+                        CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
+                        CFGNode.Constant(24),
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `generates variable access to source variable of ancestor function`() {
+            // let h = [] -> Int => (
+            //     let x = 10; #allocated on stack
+            //     let g = [] -> Int => (
+            //         let f = [] -> Int => (
+            //             x #variable access
+            //         );
+            //     );
+            // )
+
+            // given
+            val xDef = Definition.VariableDeclaration(mockRange, "x", null, Literal.IntLiteral(mockRange, 10))
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    VariableUse(mockRange, "x"),
+                )
+            val gDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "g",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    fDef,
+                )
+            val hDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "h",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Block(mockRange, listOf(xDef, gDef)),
+                )
+
+            val xAnalyzed = AnalyzedVariable(xDef, hDef, VariableUseType.READ_WRITE)
+            val fAnalyzed =
+                AnalyzedFunction(
+                    ParentLink(gDef, true),
+                    setOf(xAnalyzed),
+                    mutableSetOf(),
+                    2,
+                    setOf(),
+                )
+            val gAnalyzed =
+                AnalyzedFunction(
+                    ParentLink(hDef, true),
+                    setOf(xAnalyzed),
+                    mutableSetOf(),
+                    1,
+                    setOf(xDef),
+                )
+            val hAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(xAnalyzed),
+                    mutableSetOf(),
+                    0,
+                    setOf(xDef),
+                )
+            val hHandler = FunctionHandlerImpl(hDef, hAnalyzed, listOf())
+            val gHandler = FunctionHandlerImpl(gDef, gAnalyzed, listOf(hHandler))
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf(gHandler, hHandler))
+
+            val x = hHandler.getVariableFromDefinition(xDef)
+            hHandler.registerVariableAllocation(
+                x,
+                VariableAllocation.OnStack(24),
+            )
+            gHandler.registerVariableAllocation(
+                gHandler.getStaticLink(),
+                VariableAllocation.OnStack(8),
+            )
+            fHandler.registerVariableAllocation(
+                fHandler.getStaticLink(),
+                VariableAllocation.OnStack(32),
+            )
+
+            // when
+            val xAccess = fHandler.generateVariableAccess(x)
+
+            // then
+            assertThat(xAccess).isEqualTo(
+                CFGNode.MemoryAccess( // [[[rbp + 32] + 8] + 24]
+                    CFGNode.Addition(
+                        CFGNode.MemoryAccess(
+                            CFGNode.Addition(
+                                CFGNode.MemoryAccess(
+                                    CFGNode.Addition(
+                                        CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
+                                        CFGNode.Constant(32),
+                                    ),
+                                ),
+                                CFGNode.Constant(8),
+                            ),
+                        ),
+                        CFGNode.Constant(24),
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `generates variable access to its own static link`() {
+            // let f = [] -> Int => 42 #request static link of f
+
+            // given
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Literal.IntLiteral(mockRange, 42),
+                )
+            val fAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(),
+                    mutableSetOf(),
+                    0,
+                    setOf(),
+                )
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf())
+            fHandler.registerVariableAllocation(
+                fHandler.getStaticLink(),
+                VariableAllocation.OnStack(16),
+            )
+
+            // when
+            val staticLinkAccess = fHandler.generateVariableAccess(fHandler.getStaticLink())
+
+            // then
+            assertThat(staticLinkAccess).isEqualTo(
+                CFGNode.MemoryAccess( // [rbp + 16]
+                    CFGNode.Addition(
+                        CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
+                        CFGNode.Constant(16),
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `generates variable access to static link of its ancestor`() {
+            // let g = [] -> Int => (
+            //   let f = [] -> Int => 42 #request static link of g
+            //                           #should recursively request static link of f
+            // );
+
+            // given
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Literal.IntLiteral(mockRange, 42),
+                )
+            val gDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "g",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    fDef,
+                )
+            val fAnalyzed =
+                AnalyzedFunction(
+                    ParentLink(gDef, true),
+                    setOf(),
+                    mutableSetOf(),
+                    1,
+                    setOf(),
+                )
+            val gAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(),
+                    mutableSetOf(),
+                    0,
+                    setOf(),
+                )
+            val gHandler = FunctionHandlerImpl(gDef, gAnalyzed, listOf())
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf(gHandler))
+            gHandler.registerVariableAllocation(
+                gHandler.getStaticLink(),
+                VariableAllocation.OnStack(48),
+            )
+            fHandler.registerVariableAllocation(
+                fHandler.getStaticLink(),
+                VariableAllocation.OnStack(16),
+            )
+
+            // when
+            val staticLinkAccess = fHandler.generateVariableAccess(gHandler.getStaticLink())
+
+            // then
+            assertThat(staticLinkAccess).isEqualTo(
+                CFGNode.MemoryAccess( // [[rbp + 16] + 48]
+                    CFGNode.Addition(
+                        CFGNode.MemoryAccess(
+                            CFGNode.Addition(
+                                CFGNode.VariableUse(Register.FixedRegister(X64Register.RBP)),
+                                CFGNode.Constant(16),
+                            ),
+                        ),
+                        CFGNode.Constant(48),
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `throws if requested access to variable that is not accessible`() {
+            // given
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    listOf(),
+                    Type.Basic(mockRange, "Int"),
+                    Literal.IntLiteral(mockRange, 42),
+                )
+            val fAnalyzed =
+                AnalyzedFunction(
+                    null,
+                    setOf(),
+                    mutableSetOf(),
+                    0,
+                    setOf(),
+                )
+            val fHandler = FunctionHandlerImpl(fDef, fAnalyzed, listOf())
+
+            // when & then
+            org.junit.jupiter.api.assertThrows<GenerateVariableAccessException> {
+                fHandler.generateVariableAccess(
+                    Variable.SourceVariable(
+                        Definition.VariableDeclaration(mockRange, "x", null, Literal.IntLiteral(mockRange, 10)),
+                    ),
+                )
+            }
+        }
     }
 }

--- a/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
@@ -15,8 +15,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import kotlin.math.max
 
 class FunctionHandlerTest {
-
-
     @Nested
     inner class GenerateCall {
         private fun mockAnalyzedFunction(): AnalyzedFunction =
@@ -30,7 +28,10 @@ class FunctionHandlerTest {
                 analyzedFunction
             }
 
-        private fun mockFunDeclarationAndFunHandlerWithParents(argumentCount: Int, chainLength: Int): List<FunctionHandlerImpl> =
+        private fun mockFunDeclarationAndFunHandlerWithParents(
+            argumentCount: Int,
+            chainLength: Int
+        ): List<FunctionHandlerImpl> =
             run {
                 val functionHandlers = mutableListOf<FunctionHandlerImpl>()
                 for (i in 1..chainLength) {
@@ -47,9 +48,8 @@ class FunctionHandlerTest {
                                 mockk(),
                             ),
                             analyzedFunction,
-
                             functionHandlers.toList(),
-                        )
+                        ),
                     )
                 }
 
@@ -281,8 +281,8 @@ class FunctionHandlerTest {
     fun `initialization registers static link`() {
         val analyzedFunction = mockk<AnalyzedFunction>()
         val auxVariables = mutableSetOf<Variable.AuxVariable>()
-        every {analyzedFunction.auxVariables} returns auxVariables
-        every {analyzedFunction.variables} returns emptySet()
+        every { analyzedFunction.auxVariables } returns auxVariables
+        every { analyzedFunction.variables } returns emptySet()
         every { analyzedFunction.variablesUsedInNestedFunctions } returns emptySet()
 
         val handler = FunctionHandlerImpl(mockk(), analyzedFunction, emptyList())

--- a/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
@@ -30,7 +30,7 @@ class FunctionHandlerTest {
 
         private fun mockFunDeclarationAndFunHandlerWithParents(
             argumentCount: Int,
-            chainLength: Int
+            chainLength: Int,
         ): List<FunctionHandlerImpl> =
             run {
                 val functionHandlers = mutableListOf<FunctionHandlerImpl>()

--- a/src/test/kotlin/cacophony/semantic/FunctionAnalysisTest.kt
+++ b/src/test/kotlin/cacophony/semantic/FunctionAnalysisTest.kt
@@ -23,6 +23,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             emptySet(),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -49,6 +50,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.UNUSED)),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -76,6 +78,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.READ)),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -104,6 +107,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.WRITE)),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -133,6 +137,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.READ_WRITE)),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -161,6 +166,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             emptySet(),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -168,6 +174,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funF, false),
                             emptySet(),
+                            mutableSetOf(),
                             1,
                             emptySet(),
                         ),
@@ -197,6 +204,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.UNUSED)),
+                            mutableSetOf(),
                             0,
                             setOf(varA),
                         ),
@@ -204,6 +212,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funF, true),
                             setOf(AnalyzedVariable(varA, funF, VariableUseType.READ)),
+                            mutableSetOf(),
                             1,
                             emptySet(),
                         ),
@@ -242,6 +251,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(varA, funFoo, VariableUseType.UNUSED)),
+                            mutableSetOf(),
                             0,
                             setOf(varA),
                         ),
@@ -249,6 +259,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funFoo, true),
                             emptySet(),
+                            mutableSetOf(),
                             1,
                             emptySet(),
                         ),
@@ -256,6 +267,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funG, true),
                             setOf(AnalyzedVariable(varA, funFoo, VariableUseType.READ)),
+                            mutableSetOf(),
                             2,
                             emptySet(),
                         ),
@@ -263,6 +275,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funI, false),
                             emptySet(),
+                            mutableSetOf(),
                             2,
                             emptySet(),
                         ),
@@ -270,6 +283,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funFoo, true),
                             emptySet(),
+                            mutableSetOf(),
                             1,
                             emptySet(),
                         ),
@@ -277,6 +291,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             emptySet(),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -308,6 +323,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             null,
                             setOf(AnalyzedVariable(fooVarA, funFoo, VariableUseType.READ)),
+                            mutableSetOf(),
                             0,
                             emptySet(),
                         ),
@@ -315,6 +331,7 @@ class FunctionAnalysisTest {
                         AnalyzedFunction(
                             ParentLink(funFoo, false),
                             setOf(AnalyzedVariable(barVarA, funBar, VariableUseType.WRITE)),
+                            mutableSetOf(),
                             1,
                             emptySet(),
                         ),
@@ -347,6 +364,7 @@ class FunctionAnalysisTest {
                     AnalyzedFunction(
                         null,
                         setOf(AnalyzedVariable(argA, funF, VariableUseType.READ)),
+                        mutableSetOf(),
                         0,
                         emptySet(),
                     ),
@@ -385,6 +403,7 @@ class FunctionAnalysisTest {
                             AnalyzedVariable(argA, funF, VariableUseType.UNUSED),
                             AnalyzedVariable(argB, funF, VariableUseType.UNUSED),
                         ),
+                        mutableSetOf(),
                         0,
                         setOf(argA, argB),
                     ),
@@ -395,6 +414,7 @@ class FunctionAnalysisTest {
                             AnalyzedVariable(argA, funF, VariableUseType.READ),
                             AnalyzedVariable(argB, funF, VariableUseType.WRITE),
                         ),
+                        mutableSetOf(),
                         1,
                         emptySet(),
                     ),


### PR DESCRIPTION
I don't think it's even close to being ready, there is a lot of things to discuss (and I haven't created any tests 😿).

1)I think previous interface was missing few things, to properly generate and pass this static links we also needed to know caller function, so I slightly modified it, maybe in the wrong way.

2)On the lecture it seems like every function call gets additional argument which is staticLink to parent frame. Let's suppose we have outer function, that has inner function inside. 

- If we call inner from inner for example everything is alright, we can pass outer_link, because we have it. 
- If we call outer from inner everyhing is alright too, even if outer needs some other link because example is more nested, link will be resolved as variable.
- But what if we want to call inner from outer, we would have to pass outer_link, so to make it easy it would be nice if outer function has outer_link (if it doesn't we have to make a little if, which isn't that bad).

So right now function stores both link to itself and to parent. It makes Katzper's task easier as well I think, because when he finds function that has the variable we want to use, he can ask about link to this function directly, instead of asking from it's child, but it's small problem and it could be solved without it anyway.

One thing I'm not so sure about is that now two functions have exactly the same variable in auxVariables, I don't know if it can lead to any problems or if it's completely normal thing.

Also maybe something more is wrong, because I may have misunderstood something about variable creation and stuff, maybe Filip's PR will shine some light onto it later.
