### PR TITLE
Function call support

### DIFF
--- a/src/main/kotlin/cacophony/codegen/BlockLabel.kt
+++ b/src/main/kotlin/cacophony/codegen/BlockLabel.kt
@@ -1,3 +1,15 @@
 package cacophony.codegen
 
+import cacophony.semantic.syntaxtree.Definition
+import kotlin.math.absoluteValue
+
 data class BlockLabel(val name: String)
+
+fun functionBodyLabel(function: Definition.FunctionDeclaration): BlockLabel {
+    return BlockLabel(
+        when (function.identifier) {
+            "<program>" -> "start"
+            else -> "${function.identifier}_${function.arguments.size}_${function.hashCode().absoluteValue}"
+        },
+    )
+}

--- a/src/main/kotlin/cacophony/codegen/BlockLabel.kt
+++ b/src/main/kotlin/cacophony/codegen/BlockLabel.kt
@@ -1,15 +1,23 @@
 package cacophony.codegen
 
 import cacophony.semantic.syntaxtree.Definition
-import kotlin.math.absoluteValue
 
 data class BlockLabel(val name: String)
 
-fun functionBodyLabel(function: Definition.FunctionDeclaration): BlockLabel {
-    return BlockLabel(
-        when (function.identifier) {
-            "<program>" -> "start"
-            else -> "${function.identifier}_${function.arguments.size}_${function.hashCode().absoluteValue}"
-        },
-    )
+object FunctionBodyLabel {
+    private val functionToId = mutableMapOf<Definition.FunctionDeclaration, Int>()
+    private var lastId = 0
+
+    operator fun invoke(function: Definition.FunctionDeclaration): BlockLabel {
+        if (!functionToId.containsKey(function)) {
+            functionToId[function] = lastId++
+        }
+
+        return BlockLabel(
+            when (function.identifier) {
+                "<program>" -> "start"
+                else -> "${function.identifier}_${function.arguments.size}_id${functionToId[function]}"
+            },
+        )
+    }
 }

--- a/src/main/kotlin/cacophony/codegen/BlockLabel.kt
+++ b/src/main/kotlin/cacophony/codegen/BlockLabel.kt
@@ -1,23 +1,15 @@
 package cacophony.codegen
 
 import cacophony.semantic.syntaxtree.Definition
+import kotlin.math.absoluteValue
 
 data class BlockLabel(val name: String)
 
-object FunctionBodyLabel {
-    private val functionToId = mutableMapOf<Definition.FunctionDeclaration, Int>()
-    private var lastId = 0
-
-    operator fun invoke(function: Definition.FunctionDeclaration): BlockLabel {
-        if (!functionToId.containsKey(function)) {
-            functionToId[function] = lastId++
-        }
-
-        return BlockLabel(
-            when (function.identifier) {
-                "<program>" -> "start"
-                else -> "${function.identifier}_${function.arguments.size}_id${functionToId[function]}"
-            },
-        )
-    }
+fun functionBodyLabel(function: Definition.FunctionDeclaration): BlockLabel {
+    return BlockLabel(
+        when (function.identifier) {
+            "<program>" -> "start"
+            else -> "${function.identifier}_${function.arguments.size}_${function.hashCode().absoluteValue}"
+        },
+    )
 }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -1,11 +1,13 @@
 package cacophony.codegen.instructions.cacophonyInstructions
 
 import cacophony.codegen.BlockLabel
+import cacophony.codegen.FunctionBodyLabel
 import cacophony.codegen.instructions.Instruction
 import cacophony.controlflow.HardwareRegister
 import cacophony.controlflow.HardwareRegisterMapping
 import cacophony.controlflow.PRESERVED_REGISTERS
 import cacophony.controlflow.Register
+import cacophony.semantic.syntaxtree.Definition
 
 data class PushReg(
     val reg: Register,
@@ -78,7 +80,7 @@ data class Jz(override val label: BlockLabel) : InstructionTemplates.JccInstruct
 data class Jnz(override val label: BlockLabel) : InstructionTemplates.JccInstruction(label, "jnz")
 
 data class Call(
-    val label: BlockLabel,
+    val function: Definition.FunctionDeclaration,
 ) : Instruction {
     override val registersRead: Set<Register> =
         setOf(Register.FixedRegister(HardwareRegister.RSP)).union(
@@ -86,7 +88,7 @@ data class Call(
         )
     override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
 
-    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${label.name}"
+    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${FunctionBodyLabel(function).name}"
 }
 
 class Ret : Instruction {

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -1,7 +1,7 @@
 package cacophony.codegen.instructions.cacophonyInstructions
 
 import cacophony.codegen.BlockLabel
-import cacophony.codegen.FunctionBodyLabel
+import cacophony.codegen.functionBodyLabel
 import cacophony.codegen.instructions.Instruction
 import cacophony.controlflow.HardwareRegister
 import cacophony.controlflow.HardwareRegisterMapping
@@ -88,7 +88,7 @@ data class Call(
         )
     override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
 
-    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${FunctionBodyLabel(function).name}"
+    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${functionBodyLabel(function).name}"
 }
 
 class Ret : Instruction {

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -4,6 +4,7 @@ import cacophony.codegen.BlockLabel
 import cacophony.codegen.instructions.Instruction
 import cacophony.controlflow.HardwareRegister
 import cacophony.controlflow.HardwareRegisterMapping
+import cacophony.controlflow.PRESERVED_REGISTERS
 import cacophony.controlflow.Register
 
 data class PushReg(
@@ -79,7 +80,10 @@ data class Jnz(override val label: BlockLabel) : InstructionTemplates.JccInstruc
 data class Call(
     val label: BlockLabel,
 ) : Instruction {
-    override val registersRead: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
+    override val registersRead: Set<Register> =
+        setOf(Register.FixedRegister(HardwareRegister.RSP)).union(
+            PRESERVED_REGISTERS.map { Register.FixedRegister(it) },
+        )
     override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
 
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${label.name}"
@@ -87,7 +91,17 @@ data class Call(
 
 class Ret : Instruction {
     override val registersRead: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
-    override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
+    override val registersWritten: Set<Register> =
+        setOf(Register.FixedRegister(HardwareRegister.RSP)).union(
+            PRESERVED_REGISTERS.map { Register.FixedRegister(it) },
+        )
 
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "ret"
+}
+
+class Label(val label: BlockLabel) : Instruction {
+    override val registersRead: Set<Register> = setOf()
+    override val registersWritten: Set<Register> = setOf()
+
+    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "_${label.name}:"
 }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -94,7 +94,7 @@ data class Call(
 class Ret : Instruction {
     override val registersRead: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RSP))
     override val registersWritten: Set<Register> =
-        setOf(Register.FixedRegister(HardwareRegister.RSP)).union(
+        setOf(Register.FixedRegister(HardwareRegister.RSP), Register.FixedRegister(HardwareRegister.RAX)).union(
             PRESERVED_REGISTERS.map { Register.FixedRegister(it) },
         )
 

--- a/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
@@ -1,7 +1,7 @@
 package cacophony.codegen.instructions.matching
 
 import cacophony.codegen.BlockLabel
-import cacophony.codegen.functionBodyLabel
+import cacophony.codegen.FunctionBodyLabel
 import cacophony.codegen.instructions.InstructionMaker
 import cacophony.codegen.patterns.*
 import cacophony.controlflow.*
@@ -131,7 +131,7 @@ class InstructionMatcherImpl(
 
             if (node is CFGNode.Call) {
                 matchMetadata.functionLabelFill =
-                    functionBodyLabel(
+                    FunctionBodyLabel(
                         node.declaration ?: error("Creating function body label of a pattern node"),
                     )
             }

--- a/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
@@ -1,6 +1,7 @@
 package cacophony.codegen.instructions.matching
 
 import cacophony.codegen.BlockLabel
+import cacophony.codegen.functionBodyLabel
 import cacophony.codegen.instructions.InstructionMaker
 import cacophony.codegen.patterns.*
 import cacophony.controlflow.*
@@ -47,6 +48,7 @@ class InstructionMatcherImpl(
                         mapping,
                         metadata.registerFill,
                         metadata.constantFill,
+                        metadata.functionLabelFill,
                     ),
                 )
             }
@@ -76,6 +78,7 @@ class InstructionMatcherImpl(
         val registerFill: MutableMap<RegisterLabel, Register> = mutableMapOf(),
         val constantFill: MutableMap<ConstantLabel, CFGNode.Constant> = mutableMapOf(),
         val toFill: MutableMap<ValueLabel, CFGNode> = mutableMapOf(),
+        var functionLabelFill: BlockLabel? = null,
         var size: Int = 0,
     )
 
@@ -124,6 +127,13 @@ class InstructionMatcherImpl(
             if (pattern::class != node::class) return false
             for ((nestedNode, nestedPattern) in node.children().zip(pattern.children())) {
                 if (!tryMatch(nestedNode, nestedPattern, matchMetadata)) return false
+            }
+
+            if (node is CFGNode.Call) {
+                matchMetadata.functionLabelFill =
+                    functionBodyLabel(
+                        node.declaration ?: error("Creating function body label of a pattern node"),
+                    )
             }
         }
         return true

--- a/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/matching/InstructionMatcher.kt
@@ -79,7 +79,7 @@ class InstructionMatcherImpl(
         val registerFill: MutableMap<RegisterLabel, Register> = mutableMapOf(),
         val constantFill: MutableMap<ConstantLabel, CFGNode.Constant> = mutableMapOf(),
         val toFill: MutableMap<ValueLabel, CFGNode> = mutableMapOf(),
-        var functionFill: MutableMap<FunctionLabel, CFGNode.Function> = mutableMapOf(),
+        val functionFill: MutableMap<FunctionLabel, CFGNode.Function> = mutableMapOf(),
         var size: Int = 0,
     )
 

--- a/src/main/kotlin/cacophony/codegen/linearization/Linearization.kt
+++ b/src/main/kotlin/cacophony/codegen/linearization/Linearization.kt
@@ -15,6 +15,7 @@ private typealias PartialLinearization = Pair<MutableBasicBlock, Iterator<Mutabl
 private class MutableBasicBlock(
     val label: BlockLabel,
     val instructions: MutableList<Instruction> = mutableListOf(),
+//    val instructions: MutableList<Instruction> = mutableListOf(Label(label)),
     val successors: MutableSet<MutableBasicBlock> = mutableSetOf(),
     val predecessors: MutableSet<MutableBasicBlock> = mutableSetOf(),
 ) : BasicBlock {
@@ -34,6 +35,7 @@ private class Linearizer(val fragment: CFGFragment, val covering: InstructionCov
     var blocks = 0
 
     fun getLabel() = BlockLabel("bb${blocks++}")
+//    fun getLabel() = BlockLabel("bb${blocks++}_${fragment.hashCode().absoluteValue}")
 
     fun dfs(label: CFGLabel): PartialLinearization {
         val vertex = fragment.vertices[label]!!

--- a/src/main/kotlin/cacophony/codegen/patterns/Pattern.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/Pattern.kt
@@ -8,7 +8,7 @@ data class SlotFill(
     val valueFill: Map<ValueLabel, Register>,
     val registerFill: Map<RegisterLabel, Register>,
     val constantFill: Map<ConstantLabel, CFGNode.Constant>,
-    val functionLabelFill: BlockLabel? = null,
+    val functionFill: Map<FunctionLabel, CFGNode.Function>,
 )
 
 sealed interface Pattern {

--- a/src/main/kotlin/cacophony/codegen/patterns/Pattern.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/Pattern.kt
@@ -8,6 +8,7 @@ data class SlotFill(
     val valueFill: Map<ValueLabel, Register>,
     val registerFill: Map<RegisterLabel, Register>,
     val constantFill: Map<ConstantLabel, CFGNode.Constant>,
+    val functionLabelFill: BlockLabel? = null,
 )
 
 sealed interface Pattern {

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
@@ -146,6 +146,10 @@ class InstructionBuilder(val slotFill: SlotFill) {
         instructions.add(MovzxReg64Reg8(register, registerByte))
     }
 
+    fun call() {
+        instructions.add(Call(slotFill.functionLabelFill!!))
+    }
+
     fun ret() {
         instructions.add(Ret())
     }

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
@@ -6,10 +6,7 @@ import cacophony.codegen.instructions.MemoryAddress
 import cacophony.codegen.instructions.RegisterByte
 import cacophony.codegen.instructions.cacophonyInstructions.*
 import cacophony.codegen.patterns.SlotFill
-import cacophony.controlflow.ConstantLabel
-import cacophony.controlflow.Register
-import cacophony.controlflow.RegisterLabel
-import cacophony.controlflow.ValueLabel
+import cacophony.controlflow.*
 
 class InstructionBuilder(val slotFill: SlotFill) {
     private val instructions = mutableListOf<Instruction>()
@@ -146,8 +143,13 @@ class InstructionBuilder(val slotFill: SlotFill) {
         instructions.add(MovzxReg64Reg8(register, registerByte))
     }
 
-    fun call() {
-        instructions.add(Call(slotFill.functionLabelFill!!))
+    fun call(label: FunctionLabel) {
+        instructions.add(
+            Call(
+                slotFill.functionFill.getValue(label).function
+                    ?: error("Creating function body label of a pattern node"),
+            ),
+        )
     }
 
     fun ret() {

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -22,6 +22,7 @@ val sideEffectPatterns =
         DivisionAssignmentMemoryPattern,
         ModuloAssignmentRegisterPattern,
         ModuloAssignmentMemoryPattern,
+        CallPattern,
         ReturnPattern,
         PushPattern,
         PushRegPattern,
@@ -174,6 +175,15 @@ object ModuloAssignmentMemoryPattern : SideEffectPattern, MemoryAssignmentTempla
             cqo()
             idiv(reg(rhsLabel))
             mov(mem(reg(lhsLabel)), rdx)
+        }
+}
+
+object CallPattern : SideEffectPattern {
+    override val tree = CFGNode.Call(null)
+
+    override fun makeInstance(fill: SlotFill) =
+        instructions(fill) {
+            call()
         }
 }
 

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -179,11 +179,13 @@ object ModuloAssignmentMemoryPattern : SideEffectPattern, MemoryAssignmentTempla
 }
 
 object CallPattern : SideEffectPattern {
-    override val tree = CFGNode.Call(null)
+    private val functionLabel = FunctionLabel()
+
+    override val tree = CFGNode.Call(CFGNode.FunctionSlot(functionLabel))
 
     override fun makeInstance(fill: SlotFill) =
         instructions(fill) {
-            call()
+            call(functionLabel)
         }
 }
 

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -36,10 +36,11 @@ sealed interface CFGNode {
         Leaf
 
     data class Call(
-        val declaration: Definition.FunctionDeclaration,
+        // declaration is nullable to create pattern without specific function
+        val declaration: Definition.FunctionDeclaration?,
     ) :
         Leaf {
-        override fun toString(): String = "call ${declaration.identifier}"
+        override fun toString(): String = "call ${declaration?.identifier}"
     }
 
     // NOTE: Push may be unnecessary since it can be done via Assignment + MemoryAccess

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -1,6 +1,6 @@
 package cacophony.pipeline
 
-import cacophony.codegen.FunctionBodyLabel
+import cacophony.codegen.functionBodyLabel
 import cacophony.codegen.instructions.CacophonyInstructionCovering
 import cacophony.codegen.instructions.cacophonyInstructions.Label
 import cacophony.codegen.instructions.matching.CacophonyInstructionMatcher
@@ -224,7 +224,7 @@ class CacophonyPipeline(
 
         return covering.mapValues { (function, loweredCFG) ->
             run {
-                val bodyLabel = Label(FunctionBodyLabel(function))
+                val bodyLabel = Label(functionBodyLabel(function))
                 val instructions = listOf(bodyLabel) + loweredCFG.flatMap { fragment -> fragment.instructions() }
                 val ra = registerAllocation[function] ?: error("No register allocation for function $function")
                 cacophony.codegen.instructions.generateAsm(instructions, ra)

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -1,6 +1,8 @@
 package cacophony.pipeline
 
+import cacophony.codegen.functionBodyLabel
 import cacophony.codegen.instructions.CacophonyInstructionCovering
+import cacophony.codegen.instructions.cacophonyInstructions.Label
 import cacophony.codegen.instructions.matching.CacophonyInstructionMatcher
 import cacophony.codegen.linearization.LoweredCFGFragment
 import cacophony.codegen.linearization.linearize
@@ -222,7 +224,8 @@ class CacophonyPipeline(
 
         return covering.mapValues { (function, loweredCFG) ->
             run {
-                val instructions = loweredCFG.flatMap { fragment -> fragment.instructions() }
+                val bodyLabel = Label(functionBodyLabel(function))
+                val instructions = listOf(bodyLabel) + loweredCFG.flatMap { fragment -> fragment.instructions() }
                 val ra = registerAllocation[function] ?: error("No register allocation for function $function")
                 cacophony.codegen.instructions.generateAsm(instructions, ra)
             }

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -1,6 +1,6 @@
 package cacophony.pipeline
 
-import cacophony.codegen.functionBodyLabel
+import cacophony.codegen.FunctionBodyLabel
 import cacophony.codegen.instructions.CacophonyInstructionCovering
 import cacophony.codegen.instructions.cacophonyInstructions.Label
 import cacophony.codegen.instructions.matching.CacophonyInstructionMatcher
@@ -224,7 +224,7 @@ class CacophonyPipeline(
 
         return covering.mapValues { (function, loweredCFG) ->
             run {
-                val bodyLabel = Label(functionBodyLabel(function))
+                val bodyLabel = Label(FunctionBodyLabel(function))
                 val instructions = listOf(bodyLabel) + loweredCFG.flatMap { fragment -> fragment.instructions() }
                 val ra = registerAllocation[function] ?: error("No register allocation for function $function")
                 cacophony.codegen.instructions.generateAsm(instructions, ra)

--- a/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
+++ b/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
@@ -1,8 +1,11 @@
 package cacophony.codegen.instructions.matching
 
+import cacophony.codegen.instructions.cacophonyInstructions.Call
 import cacophony.codegen.patterns.ValuePattern
 import cacophony.codegen.patterns.cacophonyPatterns.AdditionPattern
+import cacophony.codegen.patterns.cacophonyPatterns.CallPattern
 import cacophony.controlflow.*
+import cacophony.semantic.syntaxtree.Definition
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -90,5 +93,20 @@ class InstructionMatcherTest {
 
         val node = constNode add registerNode
         assertThat(instructionMatcher.findMatchesForValue(node, Register.VirtualRegister()).size).isEqualTo(1)
+    }
+
+    @Test
+    fun `matcher sets function call label`() {
+        val instructionMatcher = InstructionMatcherImpl(emptyList(), listOf(CallPattern), emptyList())
+        val function = Definition.FunctionDeclaration(mockk(), "f", mockk(), listOf(), mockk(), mockk())
+        val node = CFGNode.Call(function)
+
+        val match = instructionMatcher.findMatchesForSideEffects(node).elementAt(0)
+        val instructions = match.instructionMaker(emptyMap())
+
+        assertThat(instructions.size == 1)
+        val instruction = instructions[0]
+        assertThat(instruction is Call)
+        assertThat((instruction as Call).label.name).startsWith("f_0")
     }
 }

--- a/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
+++ b/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
@@ -1,9 +1,8 @@
 package cacophony.codegen.instructions.matching
 
-import cacophony.codegen.instructions.cacophonyInstructions.Call
+import cacophony.codegen.patterns.SideEffectPattern
 import cacophony.codegen.patterns.ValuePattern
 import cacophony.codegen.patterns.cacophonyPatterns.AdditionPattern
-import cacophony.codegen.patterns.cacophonyPatterns.CallPattern
 import cacophony.controlflow.*
 import cacophony.semantic.syntaxtree.Definition
 import io.mockk.every
@@ -76,7 +75,8 @@ class InstructionMatcherTest {
                 match {
                     it.constantFill == mapOf(constLabel to nodes[0]) &&
                         it.valueFill == mapOf(valueLabel to subOperationResult) &&
-                        it.registerFill == mapOf(registerLabel to register)
+                        it.registerFill == mapOf(registerLabel to register) &&
+                        it.functionFill == emptyMap<FunctionLabel, CFGNode.Function>()
                 },
                 resultRegister,
             )
@@ -96,17 +96,29 @@ class InstructionMatcherTest {
     }
 
     @Test
-    fun `matcher sets function call label`() {
-        val instructionMatcher = InstructionMatcherImpl(emptyList(), listOf(CallPattern), emptyList())
+    fun `function slot is filled`() {
+        val functionLabel = FunctionLabel()
+        val patternTree = CFGNode.Call(CFGNode.FunctionSlot(functionLabel))
+        val customCallPattern = mockk<SideEffectPattern>()
+        every { customCallPattern.tree } returns patternTree
+        every { customCallPattern.makeInstance(any()) } returns emptyList()
+
+        val instructionMatcher = InstructionMatcherImpl(emptyList(), listOf(customCallPattern), emptyList())
         val function = Definition.FunctionDeclaration(mockk(), "f", mockk(), listOf(), mockk(), mockk())
         val node = CFGNode.Call(function)
 
         val match = instructionMatcher.findMatchesForSideEffects(node).elementAt(0)
-        val instructions = match.instructionMaker(emptyMap())
 
-        assertThat(instructions.size == 1)
-        val instruction = instructions[0]
-        assertThat(instruction is Call)
-        assertThat((instruction as Call).label.name).startsWith("f_0")
+        match.instructionMaker(mapOf())
+        verify {
+            customCallPattern.makeInstance(
+                match {
+                    it.constantFill == emptyMap<ConstantLabel, CFGNode.Constant>() &&
+                        it.valueFill == emptyMap<ValueLabel, Register>() &&
+                        it.registerFill == emptyMap<ValueLabel, Register>() &&
+                        it.functionFill == mapOf(functionLabel to CFGNode.Function(function))
+                },
+            )
+        }
     }
 }

--- a/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
@@ -100,10 +100,16 @@ private class FragmentEquivalenceVisitor {
                 mapRegisters(actual.register, expected.register)
             }
 
+            is CFGNode.Function -> {
+                assertThat(actual).isInstanceOf(CFGNode.Function::class.java)
+                check(actual is CFGNode.Function)
+                assertThat(actual.function).isEqualTo(expected.function)
+            }
+
             is CFGNode.Call -> {
                 assertThat(actual).isInstanceOf(CFGNode.Call::class.java)
                 check(actual is CFGNode.Call)
-                assertThat(actual.declaration).isEqualTo(expected.declaration)
+                assertThat(actual.functionRef).isEqualTo(expected.functionRef)
             }
 
             is CFGNode.Constant -> {
@@ -140,6 +146,11 @@ private class FragmentEquivalenceVisitor {
             is CFGNode.ValueSlot -> {
                 assertThat(actual).isInstanceOf(CFGNode.ValueSlot::class.java)
                 check(actual is CFGNode.ValueSlot)
+            }
+
+            is CFGNode.FunctionSlot -> {
+                assertThat(actual).isInstanceOf(CFGNode.FunctionSlot::class.java)
+                check(actual is CFGNode.FunctionSlot)
             }
 
             is CFGNode.Addition -> {


### PR DESCRIPTION
<s>I've done a little bit of hacking here.

On the one hand `Call` is a `SideEfectPattern`, on the other it needs a `destinationLabel`. Moreover, `CFGNode.Call` is a data class containg a function declaration and we don't want to create a pattern for every function (possibly we can introduce new `LabelSlot`).

To not change interfaces, right now matcher fetches `destinationLabel` from CFG and passes it to `SlotFill`. </s>

New label was introduced.

I also added labels at the beginning of every `BasicBlock`, but changing tests for linearization is not trivial, so these two lines are commented and I am leaving this for @AHGIJMKLKKZNPJKQR 😉.