### PR TITLE
Complete function body

### DIFF
--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -83,12 +83,18 @@ sealed interface CFGNode {
         override fun children(): List<CFGNode> = listOf(destination)
     }
 
-    data class Constant(
-        val value: Int,
+    sealed class Constant(
+        public open val value: Int,
     ) : Value,
         Leaf {
         override fun toString(): String = value.toString()
     }
+
+    data class ConstantReal(override val value: Int) : Constant(value)
+
+    data class ConstantLazy(
+        override var value: Int,
+    ) : Constant(value)
 
     sealed interface ArithmeticOperator : Value
 
@@ -240,9 +246,9 @@ sealed interface CFGNode {
     }
 
     companion object {
-        val UNIT = Constant(42)
-        val FALSE = Constant(0)
-        val TRUE = Constant(1)
+        val UNIT = ConstantReal(42)
+        val FALSE = ConstantReal(0)
+        val TRUE = ConstantReal(1)
     }
 
     /* Slots are used by patterns only. Each slot represents some CFGNode specifying some

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -84,13 +84,13 @@ sealed interface CFGNode {
     }
 
     sealed class Constant(
-        public open val value: Int,
+        open val value: Int,
     ) : Value,
         Leaf {
         override fun toString(): String = value.toString()
     }
 
-    data class ConstantReal(override val value: Int) : Constant(value)
+    data class ConstantKnown(override val value: Int) : Constant(value)
 
     data class ConstantLazy(
         override var value: Int,
@@ -246,9 +246,9 @@ sealed interface CFGNode {
     }
 
     companion object {
-        val UNIT = ConstantReal(42)
-        val FALSE = ConstantReal(0)
-        val TRUE = ConstantReal(1)
+        val UNIT = ConstantKnown(42)
+        val FALSE = ConstantKnown(0)
+        val TRUE = ConstantKnown(1)
     }
 
     /* Slots are used by patterns only. Each slot represents some CFGNode specifying some

--- a/src/main/kotlin/cacophony/controlflow/CallConvention.kt
+++ b/src/main/kotlin/cacophony/controlflow/CallConvention.kt
@@ -1,0 +1,42 @@
+package cacophony.controlflow
+
+interface CallConvention {
+    // Where one can find the argument with the given index
+    // assuming that `push rbp` and `move rbp, rsp` happened
+    fun argumentAllocation(index: Int): VariableAllocation
+
+    // Where the returned value should be put into
+    fun returnRegister(): HardwareRegister
+
+    // Which GPR registers should be preserved by the function call (except RSP and RBP!)
+    fun preservedRegisters(): List<HardwareRegister>
+}
+
+abstract class StackCallConvention(private val registerOrder: List<HardwareRegister>) : CallConvention {
+    override fun argumentAllocation(index: Int): VariableAllocation =
+        if (index < registerOrder.size) {
+            VariableAllocation.InRegister(Register.FixedRegister(registerOrder[index]))
+        } else {
+            // Stack is
+            // [arg2]
+            // [arg1]
+            // [arg0] + 16
+            // [ret address] +8
+            // [old rbp] <- curr rbp
+            // so do your math
+            VariableAllocation.OnStack(-REGISTER_SIZE * (index - registerOrder.size + 2))
+        }
+}
+
+object SystemVAMD64CallConvention : StackCallConvention(REGISTER_ARGUMENT_ORDER) {
+    private val preservedRegisters =
+        HardwareRegister.entries.filter {
+            it != HardwareRegister.RSP &&
+                it != HardwareRegister.RBP &&
+                it.isCallPreserved
+        }
+
+    override fun returnRegister(): HardwareRegister = HardwareRegister.RAX
+
+    override fun preservedRegisters(): List<HardwareRegister> = preservedRegisters
+}

--- a/src/main/kotlin/cacophony/controlflow/CallConvention.kt
+++ b/src/main/kotlin/cacophony/controlflow/CallConvention.kt
@@ -20,11 +20,11 @@ abstract class StackCallConvention(private val registerOrder: List<HardwareRegis
             // Stack is
             // [arg2]
             // [arg1]
-            // [arg0] + 16
-            // [ret address] +8
-            // [old rbp] <- curr rbp
-            // so do your math
-            VariableAllocation.OnStack(-REGISTER_SIZE * (index - registerOrder.size + 2))
+            // [arg0] + 24
+            // [ret address] + 16
+            // [old rbp] + 8
+            // [static link] <- curr rbp
+            VariableAllocation.OnStack(-REGISTER_SIZE * (index - registerOrder.size + 3))
         }
 }
 

--- a/src/main/kotlin/cacophony/controlflow/CallConvention.kt
+++ b/src/main/kotlin/cacophony/controlflow/CallConvention.kt
@@ -30,11 +30,7 @@ abstract class StackCallConvention(private val registerOrder: List<HardwareRegis
 
 object SystemVAMD64CallConvention : StackCallConvention(REGISTER_ARGUMENT_ORDER) {
     private val preservedRegisters =
-        HardwareRegister.entries.filter {
-            it != HardwareRegister.RSP &&
-                it != HardwareRegister.RBP &&
-                it.isCallPreserved
-        }
+        listOf(HardwareRegister.RBX, HardwareRegister.R12, HardwareRegister.R13, HardwareRegister.R14, HardwareRegister.R15)
 
     override fun returnRegister(): HardwareRegister = HardwareRegister.RAX
 

--- a/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
@@ -202,7 +202,7 @@ class FunctionHandlerImpl(
                 MemoryAccess(
                     CFGNode.Subtraction(
                         generateAccessToFramePointer(definedInDeclaration),
-                        CFGNode.ConstantReal(variableAllocation.offset),
+                        CFGNode.ConstantKnown(variableAllocation.offset),
                     ),
                 )
             }
@@ -292,7 +292,7 @@ class PrologueEpilogueHandler(
         val nodes = mutableListOf<CFGNode>()
         with(handler) {
             nodes.add(pushRegister(rbp))
-            nodes.add(registerUse(rbp) assign (registerUse(rsp) sub CFGNode.ConstantReal(REGISTER_SIZE)))
+            nodes.add(registerUse(rbp) assign (registerUse(rsp) sub CFGNode.ConstantKnown(REGISTER_SIZE)))
             nodes.add(registerUse(rsp) subeq stackSpace)
 
             // Preserved registers
@@ -328,7 +328,7 @@ class PrologueEpilogueHandler(
         nodes.add(registerUse(Register.FixedRegister(callConvention.returnRegister())) assign registerUse(resultAccess))
 
         // Restoring RSP
-        nodes.add(registerUse(rsp) assign (registerUse(rbp) add CFGNode.ConstantReal(REGISTER_SIZE)))
+        nodes.add(registerUse(rsp) assign (registerUse(rbp) add CFGNode.ConstantKnown(REGISTER_SIZE)))
 
         // Restoring RBP
         nodes.add(popRegister(rbp))
@@ -371,9 +371,9 @@ fun generateCall(
                     CFGNode.Modulo(
                         Addition(
                             RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
-                            CFGNode.ConstantReal(stackArguments.size % 2 * REGISTER_SIZE),
+                            CFGNode.ConstantKnown(stackArguments.size % 2 * REGISTER_SIZE),
                         ),
-                        CFGNode.ConstantReal(16),
+                        CFGNode.ConstantKnown(16),
                     ),
                 ),
             ),
@@ -401,7 +401,7 @@ fun generateCall(
                 RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
                 Addition(
                     RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
-                    CFGNode.ConstantReal(REGISTER_SIZE * stackArguments.size),
+                    CFGNode.ConstantKnown(REGISTER_SIZE * stackArguments.size),
                 ),
             ),
         )

--- a/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/FunctionHandler.kt
@@ -1,7 +1,6 @@
 package cacophony.controlflow
 
 import cacophony.controlflow.CFGNode.Addition
-import cacophony.controlflow.CFGNode.Constant
 import cacophony.controlflow.CFGNode.MemoryAccess
 import cacophony.controlflow.CFGNode.RegisterUse
 import cacophony.semantic.AnalyzedFunction
@@ -10,7 +9,10 @@ import cacophony.semantic.syntaxtree.Definition
 import cacophony.semantic.syntaxtree.Definition.FunctionDeclaration
 import cacophony.utils.CompileException
 
-fun generateFunctionHandlers(analyzedFunctions: FunctionAnalysisResult): Map<FunctionDeclaration, FunctionHandler> {
+fun generateFunctionHandlers(
+    analyzedFunctions: FunctionAnalysisResult,
+    callConvention: CallConvention,
+): Map<FunctionDeclaration, FunctionHandler> {
     val handlers = mutableMapOf<FunctionDeclaration, FunctionHandler>()
     val order = analyzedFunctions.entries.sortedBy { it.value.staticDepth }
 
@@ -18,14 +20,14 @@ fun generateFunctionHandlers(analyzedFunctions: FunctionAnalysisResult): Map<Fun
 
     for ((function, analyzedFunction) in order) {
         if (analyzedFunction.parentLink == null) {
-            handlers[function] = FunctionHandlerImpl(function, analyzedFunction, emptyList())
+            handlers[function] = FunctionHandlerImpl(function, analyzedFunction, emptyList(), callConvention)
         } else {
             val parentHandler =
                 handlers[analyzedFunction.parentLink.parent]
                     ?: throw CompileException("Parent function handler not found")
             val functionAncestorHandlers =
                 listOf(parentHandler) + (ancestorHandlers[analyzedFunction.parentLink.parent] ?: emptyList())
-            handlers[function] = FunctionHandlerImpl(function, analyzedFunction, functionAncestorHandlers)
+            handlers[function] = FunctionHandlerImpl(function, analyzedFunction, functionAncestorHandlers, callConvention)
             ancestorHandlers[function] = functionAncestorHandlers
         }
     }
@@ -71,6 +73,8 @@ interface FunctionHandler {
     fun generatePrologue(): List<CFGNode>
 
     fun generateEpilogue(): List<CFGNode>
+
+    fun getResultRegister(): Register.VirtualRegister
 }
 
 class GenerateVariableAccessException(
@@ -79,9 +83,10 @@ class GenerateVariableAccessException(
 
 class FunctionHandlerImpl(
     val function: FunctionDeclaration,
-    val analyzedFunction: AnalyzedFunction,
+    private val analyzedFunction: AnalyzedFunction,
     // List of parents' handlers ordered from immediate parent.
     private val ancestorFunctionHandlers: List<FunctionHandler>,
+    callConvention: CallConvention,
 ) : FunctionHandler {
     private val staticLink: Variable.AuxVariable.StaticLinkVariable = Variable.AuxVariable.StaticLinkVariable()
     private val definitionToVariable =
@@ -195,9 +200,9 @@ class FunctionHandlerImpl(
 
             is VariableAllocation.OnStack -> {
                 MemoryAccess(
-                    Addition(
+                    CFGNode.Subtraction(
                         generateAccessToFramePointer(definedInDeclaration),
-                        Constant(variableAllocation.offset),
+                        CFGNode.ConstantReal(variableAllocation.offset),
                     ),
                 )
             }
@@ -216,43 +221,9 @@ class FunctionHandlerImpl(
 
     override fun getStaticLink(): Variable.AuxVariable.StaticLinkVariable = staticLink
 
-    private val prologueEpilogueHandler =
-        PrologueEpilogueHandler(
-            this,
-            ::defaultCallConvention,
-            PRESERVED_REGISTERS,
-        )
-
-    override fun generatePrologue(): List<CFGNode> = prologueEpilogueHandler.generatePrologue()
-
-    override fun generateEpilogue(): List<CFGNode> = prologueEpilogueHandler.generateEpilogue()
-
-    // Creates staticLink auxVariable in analyzedFunction, therefore shouldn't be called multiple times.
-    // Static link is created even if parent doesn't exist.
-    private fun introduceStaticLinksParams() {
-        registerVariableAllocation(
-            staticLink,
-            VariableAllocation.OnStack(0),
-        )
-        analyzedFunction.auxVariables.add(staticLink)
-    }
-}
-
-fun defaultCallConvention(index: Int): CFGNode {
-    if (index < REGISTER_ARGUMENT_ORDER.size)
-        return registerUse(Register.FixedRegister(REGISTER_ARGUMENT_ORDER[index]))
-    val over = index - REGISTER_ARGUMENT_ORDER.size
-    // Assumes that the RSP has not changed after `call f`
-    return memoryAccess(registerUse(rsp) add integer((over + 1) * REGISTER_SIZE))
-}
-
-class PrologueEpilogueHandler(
-    private val handler: FunctionHandlerImpl,
-    private val callConvention: (Int) -> CFGNode,
-    private val preservedRegisters: List<HardwareRegister>, // without RSP
-) {
-    private val numberOfStackVariables =
-        with(handler) {
+    // Can be changed by `allocateFrameVariable()` method
+    private val stackSpace: CFGNode.ConstantLazy =
+        run {
             val variables =
                 analyzedFunction
                     .declaredVariables()
@@ -271,42 +242,77 @@ class PrologueEpilogueHandler(
                         throw IllegalStateException("Holes in stack")
                     offset += REGISTER_SIZE
                 }
-                if (preservedRegisters.contains(HardwareRegister.RSP))
+                if (callConvention.preservedRegisters().contains(HardwareRegister.RSP))
                     throw IllegalArgumentException("RSP amongst call preserved registers")
+                if (callConvention.preservedRegisters().contains(HardwareRegister.RBP))
+                    throw IllegalArgumentException("RBP amongst call preserved registers")
             }
-            stackVariables.size
+            CFGNode.ConstantLazy(stackVariables.size * REGISTER_SIZE)
         }
 
-    private fun lvalueFromAllocation(allocation: VariableAllocation): CFGNode.LValue =
-        when (allocation) {
-            is VariableAllocation.InRegister -> registerUse(allocation.register)
-            is VariableAllocation.OnStack -> memoryAccess(registerUse(rsp) sub integer(allocation.offset + REGISTER_SIZE))
+    private val resultRegister = Register.VirtualRegister()
+
+    override fun getResultRegister(): Register.VirtualRegister = resultRegister
+
+    private val prologueEpilogueHandler =
+        PrologueEpilogueHandler(
+            this,
+            callConvention,
+            stackSpace,
+            resultRegister,
+        )
+
+    override fun generatePrologue(): List<CFGNode> = prologueEpilogueHandler.generatePrologue()
+
+    override fun generateEpilogue(): List<CFGNode> = prologueEpilogueHandler.generateEpilogue()
+
+    // Creates staticLink auxVariable in analyzedFunction, therefore shouldn't be called multiple times.
+    // Static link is created even if parent doesn't exist.
+    private fun introduceStaticLinksParams() {
+        registerVariableAllocation(
+            staticLink,
+            VariableAllocation.OnStack(0),
+        )
+        analyzedFunction.auxVariables.add(staticLink)
+    }
+}
+
+class PrologueEpilogueHandler(
+    private val handler: FunctionHandler,
+    private val callConvention: CallConvention,
+    private val stackSpace: CFGNode.ConstantLazy,
+    private val resultAccess: Register.VirtualRegister,
+) {
+    private val spaceForPreservedRegisters: List<Register.VirtualRegister> =
+        callConvention.preservedRegisters().map {
+            Register.VirtualRegister()
         }
 
     fun generatePrologue(): List<CFGNode> {
         val nodes = mutableListOf<CFGNode>()
         with(handler) {
-            // Move first, then change RSP, so that the offsets from the callConvention hold
-            // However, keep the existence of red zone in mind
+            nodes.add(pushRegister(rbp))
+            nodes.add(registerUse(rbp) assign (registerUse(rsp) sub CFGNode.ConstantReal(REGISTER_SIZE)))
+            nodes.add(registerUse(rsp) subeq stackSpace)
+
+            // Preserved registers
+            for ((source, destination) in callConvention.preservedRegisters() zip spaceForPreservedRegisters) {
+                nodes.add(registerUse(destination) assign registerUse(Register.FixedRegister(source)))
+            }
 
             // Defined function arguments
-            for ((ind, arg) in function.arguments.withIndex()) {
+            for ((ind, arg) in getFunctionDeclaration().arguments.withIndex()) {
                 nodes.add(
-                    lvalueFromAllocation(getVariableAllocation(getVariableFromDefinition(arg))) assign
-                        callConvention(ind),
+                    wrapAllocation(getVariableAllocation(getVariableFromDefinition(arg))) assign
+                        wrapAllocation(callConvention.argumentAllocation(ind)),
                 )
             }
+
             // Static link (implicit arg)
             nodes.add(
-                lvalueFromAllocation(getVariableAllocation(getStaticLink())) assign
-                    callConvention(function.arguments.size),
+                wrapAllocation(getVariableAllocation(getStaticLink())) assign
+                    wrapAllocation(callConvention.argumentAllocation(getFunctionDeclaration().arguments.size)),
             )
-            // Space for all stack variables
-            nodes.add(registerUse(rsp) subeq integer(numberOfStackVariables * REGISTER_SIZE))
-            // Preserved registers
-            for (register in preservedRegisters) {
-                nodes.add(pushRegister(Register.FixedRegister(register)))
-            }
         }
         return nodes
     }
@@ -314,11 +320,19 @@ class PrologueEpilogueHandler(
     fun generateEpilogue(): List<CFGNode> {
         val nodes = mutableListOf<CFGNode>()
         // Restoring preserved registers
-        for (register in preservedRegisters.reversed()) {
-            nodes.add(popRegister(Register.FixedRegister(register)))
+        for ((destination, source) in callConvention.preservedRegisters() zip spaceForPreservedRegisters) {
+            nodes.add(registerUse(Register.FixedRegister(destination)) assign registerUse(source))
         }
+
+        // Write the result to its destination
+        nodes.add(registerUse(Register.FixedRegister(callConvention.returnRegister())) assign registerUse(resultAccess))
+
         // Restoring RSP
-        nodes.add(registerUse(rsp) addeq integer(numberOfStackVariables * REGISTER_SIZE))
+        nodes.add(registerUse(rsp) assign (registerUse(rbp) add CFGNode.ConstantReal(REGISTER_SIZE)))
+
+        // Restoring RBP
+        nodes.add(popRegister(rbp))
+
         return nodes
     }
 }
@@ -357,9 +371,9 @@ fun generateCall(
                     CFGNode.Modulo(
                         Addition(
                             RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
-                            Constant(stackArguments.size % 2 * REGISTER_SIZE),
+                            CFGNode.ConstantReal(stackArguments.size % 2 * REGISTER_SIZE),
                         ),
-                        Constant(16),
+                        CFGNode.ConstantReal(16),
                     ),
                 ),
             ),
@@ -387,7 +401,7 @@ fun generateCall(
                 RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
                 Addition(
                     RegisterUse(Register.FixedRegister(HardwareRegister.RSP)),
-                    Constant(REGISTER_SIZE * stackArguments.size),
+                    CFGNode.ConstantReal(REGISTER_SIZE * stackArguments.size),
                 ),
             ),
         )

--- a/src/main/kotlin/cacophony/controlflow/HardwareRegister.kt
+++ b/src/main/kotlin/cacophony/controlflow/HardwareRegister.kt
@@ -2,25 +2,24 @@ package cacophony.controlflow
 
 const val REGISTER_SIZE = 8
 
-val PRESERVED_REGISTERS = HardwareRegister.entries.filter { it != HardwareRegister.RSP && it.isCallPreserved }
-
-enum class HardwareRegister(val isCallPreserved: Boolean) {
-    RAX(false),
-    RBX(true),
-    RCX(false),
-    RDX(false),
-    RSI(false),
-    RDI(false),
-    RSP(true),
-    RBP(true),
-    R8(false),
-    R9(false),
-    R10(false),
-    R11(false),
-    R12(true),
-    R13(true),
-    R14(true),
-    R15(true), ;
+enum class HardwareRegister {
+    RAX,
+    RBX,
+    RCX,
+    RDX,
+    RSI,
+    RDI,
+    RSP,
+    RBP,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+    ;
 
     override fun toString(): String = name.lowercase()
 }

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -4,10 +4,10 @@ import cacophony.codegen.instructions.CacophonyInstructionCovering
 import cacophony.codegen.instructions.matching.CacophonyInstructionMatcher
 import cacophony.codegen.linearization.LoweredCFGFragment
 import cacophony.codegen.linearization.linearize
-import cacophony.codegen.patterns.cacophonyPatterns.instructions
 import cacophony.codegen.registers.Liveness
 import cacophony.codegen.registers.RegisterAllocation
 import cacophony.controlflow.HardwareRegister
+import cacophony.controlflow.SystemVAMD64CallConvention
 import cacophony.controlflow.generateFunctionHandlers
 import cacophony.controlflow.generation.ProgramCFG
 import cacophony.controlflow.generation.generateCFG
@@ -164,16 +164,14 @@ class CacophonyPipeline(
         return result
     }
 
-    fun generateControlFlowGraph(input: Input): ProgramCFG {
-        return generateControlFlowGraph(generateAST(input))
-    }
+    fun generateControlFlowGraph(input: Input): ProgramCFG = generateControlFlowGraph(generateAST(input))
 
     fun generateControlFlowGraph(ast: AST): ProgramCFG {
         val resolvedVariables = resolveOverloads(ast)
         val callGraph = generateCallGraph(ast, resolvedVariables)
         val analyzedFunctions = analyzeFunctions(ast, resolvedVariables, callGraph)
         val analyzedExpressions = analyzeVarUseTypes(ast, resolvedVariables, analyzedFunctions)
-        val functionHandlers = generateFunctionHandlers(analyzedFunctions)
+        val functionHandlers = generateFunctionHandlers(analyzedFunctions, SystemVAMD64CallConvention)
         val cfg = generateCFG(resolvedVariables, analyzedExpressions, functionHandlers)
         logger?.logSuccessfulControlFlowGraphGeneration(cfg)
         return cfg

--- a/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
+++ b/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
@@ -29,10 +29,10 @@ class InstructionMatcherTest {
         val standardAdditionPattern = AdditionPattern
         val instructionMatcher = InstructionMatcherImpl(listOf(standardAdditionPattern, oddNumberAdditionPattern), emptyList(), emptyList())
 
-        var node = CFGNode.ConstantReal(1) add CFGNode.ConstantReal(2)
+        var node = CFGNode.ConstantKnown(1) add CFGNode.ConstantKnown(2)
         assertThat(instructionMatcher.findMatchesForValue(node, Register.VirtualRegister()).size).isEqualTo(2)
 
-        node = CFGNode.ConstantReal(1) add CFGNode.ConstantReal(1)
+        node = CFGNode.ConstantKnown(1) add CFGNode.ConstantKnown(1)
         assertThat(instructionMatcher.findMatchesForValue(node, Register.VirtualRegister()).size).isEqualTo(1)
     }
 
@@ -52,7 +52,7 @@ class InstructionMatcherTest {
 
         val register = Register.VirtualRegister()
 
-        val nodes = listOf(CFGNode.ConstantReal(1), CFGNode.ConstantReal(2) add CFGNode.ConstantReal(3), CFGNode.RegisterUse(register))
+        val nodes = listOf(CFGNode.ConstantKnown(1), CFGNode.ConstantKnown(2) add CFGNode.ConstantKnown(3), CFGNode.RegisterUse(register))
 
 //            +
 //           / \
@@ -85,7 +85,7 @@ class InstructionMatcherTest {
         val standardAdditionPattern = AdditionPattern
         val instructionMatcher = InstructionMatcherImpl(listOf(standardAdditionPattern), emptyList(), emptyList())
 
-        val constNode = CFGNode.ConstantReal(1)
+        val constNode = CFGNode.ConstantKnown(1)
         val registerNode = CFGNode.RegisterUse(Register.VirtualRegister())
 
         val node = constNode add registerNode

--- a/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
+++ b/src/test/kotlin/cacophony/codegen/instructions/matching/InstructionMatcherTest.kt
@@ -29,10 +29,10 @@ class InstructionMatcherTest {
         val standardAdditionPattern = AdditionPattern
         val instructionMatcher = InstructionMatcherImpl(listOf(standardAdditionPattern, oddNumberAdditionPattern), emptyList(), emptyList())
 
-        var node = CFGNode.Constant(1) add CFGNode.Constant(2)
+        var node = CFGNode.ConstantReal(1) add CFGNode.ConstantReal(2)
         assertThat(instructionMatcher.findMatchesForValue(node, Register.VirtualRegister()).size).isEqualTo(2)
 
-        node = CFGNode.Constant(1) add CFGNode.Constant(1)
+        node = CFGNode.ConstantReal(1) add CFGNode.ConstantReal(1)
         assertThat(instructionMatcher.findMatchesForValue(node, Register.VirtualRegister()).size).isEqualTo(1)
     }
 
@@ -52,7 +52,7 @@ class InstructionMatcherTest {
 
         val register = Register.VirtualRegister()
 
-        val nodes = listOf(CFGNode.Constant(1), CFGNode.Constant(2) add CFGNode.Constant(3), CFGNode.RegisterUse(register))
+        val nodes = listOf(CFGNode.ConstantReal(1), CFGNode.ConstantReal(2) add CFGNode.ConstantReal(3), CFGNode.RegisterUse(register))
 
 //            +
 //           / \
@@ -85,7 +85,7 @@ class InstructionMatcherTest {
         val standardAdditionPattern = AdditionPattern
         val instructionMatcher = InstructionMatcherImpl(listOf(standardAdditionPattern), emptyList(), emptyList())
 
-        val constNode = CFGNode.Constant(1)
+        val constNode = CFGNode.ConstantReal(1)
         val registerNode = CFGNode.RegisterUse(Register.VirtualRegister())
 
         val node = constNode add registerNode

--- a/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/FunctionHandlerTest.kt
@@ -70,10 +70,6 @@ class FunctionHandlerTest {
             run {
                 val functionHandlers = mutableListOf<FunctionHandlerImpl>()
                 for (i in 1..chainLength) {
-                    val analyzedFunction = mockAnalyzedFunction()
-                    val callConvention = mockk<CallConvention>()
-                    every { callConvention.preservedRegisters() } returns emptyList()
-
                     functionHandlers.add(
                         0,
                         makeDefaultHandler(
@@ -85,7 +81,7 @@ class FunctionHandlerTest {
                                 mockk(),
                                 mockk(),
                             ),
-                            analyzedFunction,
+                            mockAnalyzedFunction(),
                             functionHandlers.toList(),
                         ),
                     )

--- a/src/test/kotlin/cacophony/controlflow/generation/AccessTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/AccessTest.kt
@@ -23,7 +23,7 @@ class AccessTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argReg(virReg), argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, registerUse(virReg)) }
+                    "bodyEntry" does jump("exit") { writeRegister(getResultRegister(), registerUse(virReg)) }
                 }
             }
 
@@ -53,13 +53,14 @@ class AccessTest {
                     "bodyEntry" does
                         jump("exit") {
                             writeRegister(
-                                rax,
-                                memoryAccess(memoryAccess(registerUse(rbp)) add integer(8)),
+                                getResultRegister(),
+                                memoryAccess(memoryAccess(registerUse(rbp)) sub integer(8)),
                             )
                         }
                 }
             }[innerDef]!!
-
+        println(actualFragment)
+        println(expectedFragment)
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 
@@ -95,13 +96,14 @@ class AccessTest {
                     "bodyEntry" does
                         jump("exit") {
                             writeRegister(
-                                rax,
-                                memoryAccess(memoryAccess(registerUse(rbp)) add integer(8)),
+                                getResultRegister(),
+                                memoryAccess(memoryAccess(registerUse(rbp)) sub integer(8)),
                             )
                         }
                 }
             }[innerDef]!!
-
+        println(actualFragment)
+        println(expectedFragment)
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 }

--- a/src/test/kotlin/cacophony/controlflow/generation/AccessTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/AccessTest.kt
@@ -59,8 +59,7 @@ class AccessTest {
                         }
                 }
             }[innerDef]!!
-        println(actualFragment)
-        println(expectedFragment)
+
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 
@@ -102,8 +101,7 @@ class AccessTest {
                         }
                 }
             }[innerDef]!!
-        println(actualFragment)
-        println(expectedFragment)
+
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 }

--- a/src/test/kotlin/cacophony/controlflow/generation/BlocksTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/BlocksTest.kt
@@ -20,7 +20,7 @@ class BlocksTest {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does
                         jump("exit") {
-                            writeRegister(rax, unit)
+                            writeRegister(getResultRegister(), unit)
                         }
                 }
             }
@@ -42,7 +42,7 @@ class BlocksTest {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does
                         jump("exit") {
-                            writeRegister(rax, writeRegister("x", integer(1)))
+                            writeRegister(getResultRegister(), writeRegister("x", integer(1)))
                         }
                 }
             }
@@ -75,7 +75,7 @@ class BlocksTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, writeRegister("y", integer(2)))
+                            writeRegister(getResultRegister(), writeRegister("y", integer(2)))
                         }
                 }
             }

--- a/src/test/kotlin/cacophony/controlflow/generation/BreakTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/BreakTest.kt
@@ -52,7 +52,7 @@ class BreakTest {
                         jump("condition") {
                             readRegister("x") addeq integer(1)
                         }
-                    "exitWhile" does jump("exit") { writeRegister(rax, unit) }
+                    "exitWhile" does jump("exit") { writeRegister(getResultRegister(), unit) }
                 }
             }
 
@@ -108,7 +108,7 @@ class BreakTest {
                         conditional("exitWhile", "loop condition") {
                             (readRegister("x") mod integer(5)) eq integer(0)
                         }
-                    "exitWhile" does jump("exit") { writeRegister(rax, unit) }
+                    "exitWhile" does jump("exit") { writeRegister(getResultRegister(), unit) }
                 }
             }
 
@@ -139,7 +139,7 @@ class BreakTest {
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does jump("write unit to rax") { writeRegister("x", integer(2)) }
-                    "write unit to rax" does jump("exit") { writeRegister(rax, unit) }
+                    "write unit to rax" does jump("exit") { writeRegister(getResultRegister(), unit) }
                 }
             }
 
@@ -179,13 +179,13 @@ class BreakTest {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does
                         jump("condition") {
-                            cacophony.controlflow.writeRegister(virtualRegister("x"), integer(2))
+                            writeRegister(virtualRegister("x"), integer(2))
                         }
                     "condition" does
                         conditional("exitWhile", "exitWhile") {
                             readRegister("x") eq integer(2)
                         }
-                    "exitWhile" does jump("exit") { writeRegister(rax, unit) }
+                    "exitWhile" does jump("exit") { writeRegister(getResultRegister(), unit) }
                 }
             }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/CFGConditionalSimplificationTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CFGConditionalSimplificationTest.kt
@@ -27,7 +27,7 @@ class CFGConditionalSimplificationTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, integer(11)) }
+                    "bodyEntry" does jump("exit") { writeRegister(getResultRegister(), integer(11)) }
                 }
             }
         assertEquivalent(actualCFG, expectedCFG)
@@ -49,7 +49,7 @@ class CFGConditionalSimplificationTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, integer(22)) }
+                    "bodyEntry" does jump("exit") { writeRegister(getResultRegister(), integer(22)) }
                 }
             }
         assertEquivalent(actualCFG, expectedCFG)
@@ -88,7 +88,7 @@ class CFGConditionalSimplificationTest {
                     "write result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 registerUse(virtualRegister("result")),
                             )
                         }
@@ -130,7 +130,7 @@ class CFGConditionalSimplificationTest {
                     "write result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 registerUse(virtualRegister("result")),
                             )
                         }
@@ -189,7 +189,7 @@ class CFGConditionalSimplificationTest {
                     "write result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 registerUse(virtualRegister("result")),
                             )
                         }
@@ -248,7 +248,7 @@ class CFGConditionalSimplificationTest {
                     "write result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 registerUse(virtualRegister("result")),
                             )
                         }
@@ -300,7 +300,7 @@ class CFGConditionalSimplificationTest {
                     "write result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 registerUse(virtualRegister("result")),
                             )
                         }
@@ -364,7 +364,7 @@ class CFGConditionalSimplificationTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, registerUse(virtualRegister("y")))
+                            writeRegister(getResultRegister(), registerUse(virtualRegister("y")))
                         }
                 }
             }
@@ -411,7 +411,7 @@ class CFGConditionalSimplificationTest {
             cfg {
                 fragment(actualCFG.keys.first(), listOf(argStack(0)), 8) {
                     "bodyEntry" does jump("write result to rax") { writeRegister("result", integer(12)) }
-                    "write result to rax" does jump("exit") { writeRegister(rax, readRegister("result")) }
+                    "write result to rax" does jump("exit") { writeRegister(getResultRegister(), readRegister("result")) }
                 }
             }
 
@@ -443,7 +443,7 @@ class CFGConditionalSimplificationTest {
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does jump("write result to rax") { writeRegister("result", integer(20)) }
-                    "write result to rax" does jump("exit") { writeRegister(rax, readRegister("result")) }
+                    "write result to rax" does jump("exit") { writeRegister(getResultRegister(), readRegister("result")) }
                 }
             }
 
@@ -483,7 +483,7 @@ class CFGConditionalSimplificationTest {
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
                     "bodyEntry" does jump("write result to rax") { writeRegister("result", integer(11)) }
-                    "write result to rax" does jump("exit") { writeRegister(rax, readRegister("result")) }
+                    "write result to rax" does jump("exit") { writeRegister(getResultRegister(), readRegister("result")) }
                 }
             }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/CFGGenerationTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CFGGenerationTest.kt
@@ -32,7 +32,8 @@ class CFGGenerationTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, UNIT) }
+                    val resReg = getResultRegister()
+                    "bodyEntry" does jump("exit") { writeRegister(resReg, UNIT) }
                 }
             }
 
@@ -51,7 +52,7 @@ class CFGGenerationTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, TRUE) }
+                    "bodyEntry" does jump("exit") { writeRegister(getResultRegister(), TRUE) }
                 }
             }
 
@@ -91,7 +92,7 @@ class CFGGenerationTest {
                         }
                     "true" does jump("end") { writeRegister(virtualRegister("t"), integer(11)) }
                     "false" does jump("end") { writeRegister(virtualRegister("t"), integer(22)) }
-                    "end" does jump("exit") { writeRegister(rax, registerUse(virtualRegister("t"))) }
+                    "end" does jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("t"))) }
                 }
             }
 
@@ -134,7 +135,7 @@ class CFGGenerationTest {
                         jump("condition") {
                             readRegister("x") addeq integer(1)
                         }
-                    "exitWhile" does jump("exit") { writeRegister(rax, unit) }
+                    "exitWhile" does jump("exit") { writeRegister(getResultRegister(), unit) }
                 }
             }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/CallTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CallTest.kt
@@ -40,10 +40,11 @@ class CallTest {
                     "restore rsp" does jump("extract result") { popRegister(rsp) }
                     // The called function returned something, and we are using it as a value - we need to extract it from rax
                     "extract result" does jump("forward result") { writeRegister("result", registerUse(rax)) }
-                    "forward result" does jump("exit") { writeRegister(rax, registerUse(virtualRegister("result"))) }
+                    "forward result" does jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("result"))) }
                 }
             }[callerDef]!!
-
+        println(actualFragment)
+        println(expectedFragment)
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 
@@ -87,11 +88,11 @@ class CallTest {
                     "call" does jump("restore rsp") { call(calleeDef) }
                     "restore rsp" does jump("write block result to rax") { popRegister(rsp) }
                     // The called function returned something, but we don't care - we only wanted it for side effects
-                    // We don't extract anything - instead, we prepare our own block result and move it to rax
+                    // We don't extract anything - instead, we prepare our own block result and move it to getResultRegister()
                     "write block result to rax" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 integer(2),
                             )
                         }
@@ -138,7 +139,7 @@ class CallTest {
                     "call" does jump("restore rsp") { call(calleeDef) }
                     "restore rsp" does jump("extract result") { popRegister(rsp) }
                     "extract result" does jump("forward result") { writeRegister("result", registerUse(rax)) }
-                    "forward result" does jump("exit") { writeRegister(rax, registerUse(virtualRegister("result"))) }
+                    "forward result" does jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("result"))) }
                 }
             }[callerDef]!!
 
@@ -202,7 +203,7 @@ class CallTest {
                     "clear arg6" does jump("restore rsp") { writeRegister(rsp, registerUse(rsp) add integer(8)) }
                     "restore rsp" does jump("extract result") { popRegister(rsp) }
                     "extract result" does jump("forward result") { writeRegister("result", registerUse(rax)) }
-                    "forward result" does jump("exit") { writeRegister(rax, registerUse(virtualRegister("result"))) }
+                    "forward result" does jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("result"))) }
                 }
             }[callerDef]!!
 
@@ -262,7 +263,8 @@ class CallTest {
                     "call out" does jump("restore rsp out") { call(calleeDef) }
                     "restore rsp out" does jump("extract result out") { popRegister(rsp) }
                     "extract result out" does jump("forward result out") { writeRegister("result out", registerUse(rax)) }
-                    "forward result out" does jump("exit") { writeRegister(rax, registerUse(virtualRegister("result out"))) }
+                    "forward result out" does
+                        jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("result out"))) }
                 }
             }[callerDef]!!
 
@@ -302,7 +304,7 @@ class CallTest {
                     "extract result" does jump("forward result") { writeRegister("result", registerUse(rax)) }
                     "forward result" does
                         jump("exit") {
-                            writeRegister(rax, integer(1) add registerUse(virtualRegister("result")))
+                            writeRegister(getResultRegister(), integer(1) add registerUse(virtualRegister("result")))
                         }
                 }
             }

--- a/src/test/kotlin/cacophony/controlflow/generation/CallTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CallTest.kt
@@ -43,8 +43,7 @@ class CallTest {
                     "forward result" does jump("exit") { writeRegister(getResultRegister(), registerUse(virtualRegister("result"))) }
                 }
             }[callerDef]!!
-        println(actualFragment)
-        println(expectedFragment)
+
         assertFragmentIsEquivalent(actualFragment, expectedFragment)
     }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/ConditionalOperatorsTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/ConditionalOperatorsTest.kt
@@ -16,7 +16,6 @@ import cacophony.controlflow.generation.TestOperators.Companion.ltNode
 import cacophony.controlflow.generation.TestOperators.Companion.neq
 import cacophony.controlflow.generation.TestOperators.Companion.neqNode
 import cacophony.controlflow.integer
-import cacophony.controlflow.rax
 import cacophony.controlflow.writeRegister
 import cacophony.functionDeclaration
 import cacophony.ifThenElse
@@ -67,7 +66,7 @@ class ConditionalOperatorsTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, readRegister("result"))
+                            writeRegister(getResultRegister(), readRegister("result"))
                         }
                 }
             }
@@ -119,7 +118,7 @@ class ConditionalOperatorsTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, readRegister("result"))
+                            writeRegister(getResultRegister(), readRegister("result"))
                         }
                 }
             }
@@ -171,7 +170,7 @@ class ConditionalOperatorsTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, readRegister("result"))
+                            writeRegister(getResultRegister(), readRegister("result"))
                         }
                 }
             }
@@ -227,7 +226,7 @@ class ConditionalOperatorsTest {
                         }
                     "write result to rax" does
                         jump("exit") {
-                            writeRegister(rax, readRegister("result"))
+                            writeRegister(getResultRegister(), readRegister("result"))
                         }
                 }
             }

--- a/src/test/kotlin/cacophony/controlflow/generation/ReturnTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/ReturnTest.kt
@@ -11,7 +11,6 @@ import cacophony.controlflow.mod
 import cacophony.controlflow.unit
 import org.junit.jupiter.api.Test
 
-// @Disabled("TODO: Cannot handle return at the moment")
 class ReturnTest {
     @Test
     fun `return exits while(true) loop`() {

--- a/src/test/kotlin/cacophony/controlflow/generation/ReturnTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/ReturnTest.kt
@@ -8,13 +8,10 @@ import cacophony.controlflow.generation.CFGGenerationTest.Companion.pipeline
 import cacophony.controlflow.integer
 import cacophony.controlflow.lt
 import cacophony.controlflow.mod
-import cacophony.controlflow.rax
-import cacophony.controlflow.returnNode
 import cacophony.controlflow.unit
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-@Disabled("TODO: Cannot handle return at the moment")
+// @Disabled("TODO: Cannot handle return at the moment")
 class ReturnTest {
     @Test
     fun `return exits while(true) loop`() {
@@ -62,10 +59,9 @@ class ReturnTest {
                             readRegister("x") addeq integer(1)
                         }
                     "return from loop" does
-                        jump("loop return") {
-                            cacophony.controlflow.writeRegister(rax, integer(0))
+                        jump("exit") {
+                            cacophony.controlflow.writeRegister(getResultRegister(), integer(0))
                         }
-                    "loop return" does final { returnNode }
                 }
             }
 
@@ -120,9 +116,8 @@ class ReturnTest {
                         conditional("return from loop", "loop condition") {
                             (readRegister("x") mod integer(5)) eq integer(0)
                         }
-                    "exitWhile" does jump("exit") { cacophony.controlflow.writeRegister(rax, unit) }
-                    "return from loop" does jump("loop return") { cacophony.controlflow.writeRegister(rax, integer(0)) }
-                    "loop return" does final { returnNode }
+                    "exitWhile" does jump("exit") { cacophony.controlflow.writeRegister(getResultRegister(), unit) }
+                    "return from loop" does jump("exit") { cacophony.controlflow.writeRegister(getResultRegister(), integer(0)) }
                 }
             }
 
@@ -148,7 +143,7 @@ class ReturnTest {
         val expectedCFG =
             cfg {
                 fragment(fDef, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { cacophony.controlflow.writeRegister(rax, integer(1)) }
+                    "bodyEntry" does jump("exit") { cacophony.controlflow.writeRegister(getResultRegister(), integer(1)) }
                 }
             }
 
@@ -192,15 +187,13 @@ class ReturnTest {
                             readRegister("x") eq integer(2)
                         }
                     "write 1 to rax" does
-                        jump("return 1") {
-                            cacophony.controlflow.writeRegister(rax, integer(1))
+                        jump("exit") {
+                            cacophony.controlflow.writeRegister(getResultRegister(), integer(1))
                         }
                     "write 2 to rax" does
-                        jump("return 2") {
-                            cacophony.controlflow.writeRegister(rax, integer(2))
+                        jump("exit") {
+                            cacophony.controlflow.writeRegister(getResultRegister(), integer(2))
                         }
-                    "return 1" does final { returnNode }
-                    "return 2" does final { returnNode }
                 }
             }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/SideEffectSeparationTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/SideEffectSeparationTest.kt
@@ -26,7 +26,6 @@ import cacophony.controlflow.generation.TestOperators.Companion.neqNode
 import cacophony.controlflow.generation.TestOperators.Companion.sub
 import cacophony.controlflow.generation.TestOperators.Companion.subNode
 import cacophony.controlflow.integer
-import cacophony.controlflow.rax
 import cacophony.controlflow.writeRegister
 import cacophony.lit
 import cacophony.semantic.functionDeclaration
@@ -77,7 +76,7 @@ class SideEffectSeparationTest {
                     "add" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 makeNode(
                                     readRegister("lhs"),
                                     (writeRegister("x", integer(20))),
@@ -123,7 +122,7 @@ class SideEffectSeparationTest {
                     "add" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 makeNode(
                                     readRegister("lhs"),
                                     (writeRegister("x", integer(20))),
@@ -169,7 +168,7 @@ class SideEffectSeparationTest {
                     "add" does
                         jump("exit") {
                             writeRegister(
-                                rax,
+                                getResultRegister(),
                                 makeNode(
                                     readRegister("lhs"),
                                     readRegister("x"),

--- a/src/test/kotlin/cacophony/controlflow/generation/SingleCFGNodeGenerationTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/SingleCFGNodeGenerationTest.kt
@@ -17,7 +17,6 @@ import cacophony.controlflow.mod
 import cacophony.controlflow.mul
 import cacophony.controlflow.neq
 import cacophony.controlflow.not
-import cacophony.controlflow.rax
 import cacophony.controlflow.sub
 import cacophony.controlflow.trueValue
 import cacophony.controlflow.writeRegister
@@ -32,7 +31,7 @@ class SingleCFGNodeGenerationTest {
         val expectedCFG =
             cfg {
                 fragment(function, listOf(argStack(0)), 8) {
-                    "bodyEntry" does jump("exit") { writeRegister(rax, expectedNode) }
+                    "bodyEntry" does jump("exit") { writeRegister(getResultRegister(), expectedNode) }
                 }
             }
         assertEquivalent(programCFG, expectedCFG)


### PR DESCRIPTION
ReturnStatements jump to the epilogue of the function. Fixed ReturnTests.

In previous weeks we politely assumed that the rbp register points exactly to the static link (so that jumping with the static links looks like this: `[[..[rpb]..]]`). However, this clashes with typical convention where we start function with `push rbp; mov rbp, rsp;`.

There is a decision to be made, so I decided to go with the following stack outline during function call:
```
    arg8
    arg7
    return adress
    old rbp
    static link <- rbp
    memory var 1
    ...
    memory var k <- rsp
```
so that the function call looks like this:

```
    push rbp
    lea rbp, [rsp - 8]
    sub rsp, stackSpace
    mov [rbp], static_link
    [function body]
    mov rax, out_vir_reg
    lea rsp, [rbp + 8]
    pop rbp
    ret
```

to preserve that mentioned nice 'jumping structure' on the static links.

Additionally, added the `ConstantLazy` class for constants that may change after register allocation (such as stackSpace).