### PR TITLE
implement spill handling

### DIFF
--- a/src/main/kotlin/cacophony/codegen/instructions/Instruction.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/Instruction.kt
@@ -25,10 +25,11 @@ data class MemoryAddress(val base: Register, val index: Register?, val scale: In
 
 interface Instruction {
     val registersRead: Set<Register>
-
     val registersWritten: Set<Register>
 
     fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping): String
+
+    fun substituteRegisters(map: Map<Register, Register>): Instruction
 
     fun isNoop(hardwareRegisterMapping: HardwareRegisterMapping): Boolean = false
 }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ArithmeticInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ArithmeticInstructions.kt
@@ -70,8 +70,8 @@ data class IMulRegReg(
     )
 
 class Cqo : InstructionTemplates.FixedRegistersInstruction() {
-    override val registersRead: Set<Register.FixedRegister> = setOf(Register.FixedRegister(HardwareRegister.RAX))
-    override val registersWritten: Set<Register.FixedRegister> = setOf(Register.FixedRegister(HardwareRegister.RDX))
+    override val registersRead: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RAX))
+    override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RDX))
 
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "cqo"
 }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ArithmeticInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ArithmeticInstructions.kt
@@ -69,9 +69,9 @@ data class IMulRegReg(
         "imul",
     )
 
-class Cqo : Instruction {
-    override val registersRead: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RAX))
-    override val registersWritten: Set<Register> = setOf(Register.FixedRegister(HardwareRegister.RDX))
+class Cqo : InstructionTemplates.FixedRegistersInstruction() {
+    override val registersRead: Set<Register.FixedRegister> = setOf(Register.FixedRegister(HardwareRegister.RAX))
+    override val registersWritten: Set<Register.FixedRegister> = setOf(Register.FixedRegister(HardwareRegister.RDX))
 
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "cqo"
 }
@@ -85,6 +85,8 @@ data class IDiv(val reg: Register) : Instruction {
         val hardwareReg = hardwareRegisterMapping[reg]
         return "idiv $hardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): IDiv = IDiv(reg.substitute(map))
 }
 
 data class Sete(override val byte: RegisterByte) : InstructionTemplates.SetccInstruction(byte, "sete")

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -17,6 +17,8 @@ data class PushReg(
         val hardwareReg = hardwareRegisterMapping[reg]
         return "push $hardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): PushReg = PushReg(reg.substitute(map))
 }
 
 data class Pop(
@@ -29,6 +31,8 @@ data class Pop(
         val hardwareReg = hardwareRegisterMapping[reg]
         return "pop $hardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): Pop = Pop(reg.substitute(map))
 }
 
 data class TestRegReg(
@@ -43,6 +47,8 @@ data class TestRegReg(
         val rhsHardwareReg = hardwareRegisterMapping[rhs]
         return "test $lhsHardwareReg, $rhsHardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): TestRegReg = TestRegReg(lhs.substitute(map), rhs.substitute(map))
 }
 
 data class CmpRegReg(
@@ -57,6 +63,8 @@ data class CmpRegReg(
         val rhsHardwareReg = hardwareRegisterMapping[rhs]
         return "cmp $lhsHardwareReg, $rhsHardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): CmpRegReg = CmpRegReg(lhs.substitute(map), rhs.substitute(map))
 }
 
 data class Jmp(override val label: BlockLabel) : InstructionTemplates.JccInstruction(label, "jmp")
@@ -77,7 +85,7 @@ data class Jz(override val label: BlockLabel) : InstructionTemplates.JccInstruct
 
 data class Jnz(override val label: BlockLabel) : InstructionTemplates.JccInstruction(label, "jnz")
 
-data class Call(val function: Definition.FunctionDeclaration) : Instruction {
+data class Call(val function: Definition.FunctionDeclaration) : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead =
         setOf(Register.FixedRegister(HardwareRegister.RSP)) union
             SystemVAMD64CallConvention.preservedRegisters().map(Register::FixedRegister)
@@ -91,7 +99,7 @@ data class Call(val function: Definition.FunctionDeclaration) : Instruction {
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${functionBodyLabel(function).name}"
 }
 
-class Ret : Instruction {
+class Ret : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead =
         setOf(Register.FixedRegister(HardwareRegister.RSP), Register.FixedRegister(SystemVAMD64CallConvention.returnRegister()))
     override val registersWritten = setOf<Register>()
@@ -99,14 +107,14 @@ class Ret : Instruction {
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "ret"
 }
 
-data class LocalLabel(val label: BlockLabel) : Instruction {
+data class LocalLabel(val label: BlockLabel) : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead: Set<Register> = setOf()
     override val registersWritten: Set<Register> = setOf()
 
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = ".${label.name}:"
 }
 
-data class Label(val label: BlockLabel) : Instruction {
+data class Label(val label: BlockLabel) : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead: Set<Register> = setOf()
     override val registersWritten: Set<Register> = setOf()
 

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -93,6 +93,7 @@ data class Call(val function: Definition.FunctionDeclaration) : InstructionTempl
         HardwareRegister
             .entries
             .filterNot(SystemVAMD64CallConvention.preservedRegisters()::contains)
+            .minus(setOf(HardwareRegister.R8, HardwareRegister.R9))
             .map(Register::FixedRegister)
             .toSet()
 

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/InstructionTemplates.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/InstructionTemplates.kt
@@ -58,8 +58,8 @@ class InstructionTemplates {
         open val label: BlockLabel,
         private val op: String,
     ) : FixedRegistersInstruction() {
-        override val registersRead: Set<Register.FixedRegister> = setOf()
-        override val registersWritten: Set<Register.FixedRegister> = setOf()
+        override val registersRead: Set<Register> = setOf()
+        override val registersWritten: Set<Register> = setOf()
 
         override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "$op ${label.name}"
     }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/MovInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/MovInstructions.kt
@@ -21,6 +21,8 @@ data class MovRegReg(
     }
 
     override fun isNoop(hardwareRegisterMapping: HardwareRegisterMapping) = hardwareRegisterMapping[lhs] == hardwareRegisterMapping[rhs]
+
+    override fun substituteRegisters(map: Map<Register, Register>): MovRegReg = MovRegReg(lhs.substitute(map), rhs.substitute(map))
 }
 
 data class MovRegImm(
@@ -34,6 +36,8 @@ data class MovRegImm(
         val lhsHardwareReg = hardwareRegisterMapping[lhs]
         return "mov $lhsHardwareReg, $imm"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): MovRegImm = MovRegImm(lhs.substitute(map), imm)
 }
 
 data class MovRegMem(
@@ -47,6 +51,8 @@ data class MovRegMem(
         val lhsHardwareReg = hardwareRegisterMapping[lhs]
         return "mov $lhsHardwareReg, ${mem.toAsm(hardwareRegisterMapping)}"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): MovRegMem = MovRegMem(lhs.substitute(map), mem)
 }
 
 data class MovMemReg(
@@ -60,6 +66,8 @@ data class MovMemReg(
         val rhsHardwareReg = hardwareRegisterMapping[rhs]
         return "mov ${mem.toAsm(hardwareRegisterMapping)}, $rhsHardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): MovMemReg = MovMemReg(mem, rhs.substitute(map))
 }
 
 data class MovzxReg64Reg8(val lhs: Register, val rhs: RegisterByte) : Instruction {
@@ -71,4 +79,10 @@ data class MovzxReg64Reg8(val lhs: Register, val rhs: RegisterByte) : Instructio
         val rhsHardwareReg = rhs.map(hardwareRegisterMapping)
         return "movzx $lhsHardwareReg, $rhsHardwareReg"
     }
+
+    override fun substituteRegisters(map: Map<Register, Register>): MovzxReg64Reg8 =
+        MovzxReg64Reg8(
+            lhs.substitute(map),
+            RegisterByte(rhs.register.substitute(map)),
+        )
 }

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/Utils.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/Utils.kt
@@ -2,6 +2,7 @@ package cacophony.codegen.instructions.cacophonyInstructions
 
 import cacophony.codegen.instructions.MemoryAddress
 import cacophony.controlflow.HardwareRegisterMapping
+import cacophony.controlflow.Register
 
 fun MemoryAddress.toAsm(hardwareRegisterMapping: HardwareRegisterMapping): String {
     val builder = StringBuilder()
@@ -16,3 +17,5 @@ fun MemoryAddress.toAsm(hardwareRegisterMapping: HardwareRegisterMapping): Strin
     builder.append("]")
     return builder.toString()
 }
+
+fun Register.substitute(registersSubstitution: Map<Register, Register>): Register = registersSubstitution.getOrDefault(this, this)

--- a/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
+++ b/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
@@ -1,0 +1,104 @@
+package cacophony.codegen.registers
+
+import cacophony.codegen.BlockLabel
+import cacophony.codegen.instructions.Instruction
+import cacophony.codegen.instructions.InstructionCovering
+import cacophony.codegen.linearization.BasicBlock
+import cacophony.codegen.linearization.LoweredCFGFragment
+import cacophony.controlflow.CFGNode
+import cacophony.controlflow.Register
+import cacophony.controlflow.Register.FixedRegister
+import cacophony.controlflow.Register.VirtualRegister
+import cacophony.controlflow.Variable
+import cacophony.controlflow.functions.FunctionHandler
+
+class SpillHandlingException(reason: String) : Exception(reason)
+
+/**
+ * @throws SpillHandlingException if spill handling fails, i.e.
+ * - One of spare registers is used in register allocation (in the map image)
+ * - A fixed register has spilled in register allocation
+ * - Not enough spare registers provided
+ * @return List of BasicBlocks with adjusted and new instructions.
+ */
+fun adjustLoweredCFGToHandleSpills(
+    instructionCovering: InstructionCovering,
+    functionHandler: FunctionHandler,
+    loweredCfg: LoweredCFGFragment,
+    registerAllocation: RegisterAllocation,
+    spareRegisters: Set<FixedRegister>,
+): LoweredCFGFragment {
+    if (registerAllocation.successful.values
+            .intersect(spareRegisters.map { it.hardwareRegister }.toSet())
+            .isNotEmpty()
+    ) {
+        throw SpillHandlingException("Spare register is used in register allocation.")
+    }
+
+    if (registerAllocation.spills.isEmpty()) {
+        return loweredCfg
+    }
+
+    val spills: Set<VirtualRegister> =
+        registerAllocation.spills
+            .map {
+                when (it) {
+                    is FixedRegister -> throw SpillHandlingException("Fixed register $it has spilled.")
+                    is VirtualRegister -> it
+                }
+            }.toSet()
+
+    val spillsFrameAllocation: Map<VirtualRegister, CFGNode.LValue> =
+        spills.associateWith {
+            functionHandler.allocateFrameVariable(Variable.AuxVariable.SpillVariable())
+        }
+
+    fun loadSpillIntoReg(spill: VirtualRegister, reg: FixedRegister): List<Instruction> =
+        instructionCovering.coverWithInstructions(
+            CFGNode.Assignment(
+                CFGNode.RegisterUse(reg),
+                spillsFrameAllocation[spill]!!,
+            ),
+        )
+
+    fun saveRegIntoSpill(reg: FixedRegister, spill: VirtualRegister): List<Instruction> =
+        instructionCovering.coverWithInstructions(
+            CFGNode.Assignment(
+                spillsFrameAllocation[spill]!!,
+                CFGNode.RegisterUse(reg),
+            ),
+        )
+
+    return loweredCfg.map { block ->
+        val newInstructions =
+            block.instructions().flatMap { instruction ->
+                val readSpills = instruction.registersRead.filterIsInstance<VirtualRegister>().filter { spills.contains(it) }
+                val writtenSpills = instruction.registersWritten.filterIsInstance<VirtualRegister>().filter { spills.contains(it) }
+                val usedSpills = readSpills + writtenSpills
+
+                if (usedSpills.size > spareRegisters.size) {
+                    throw SpillHandlingException(
+                        "Not enough spare registers: Detected instruction with ${usedSpills.size} registers," +
+                            "but only have ${spareRegisters.size} spare registers to use",
+                    )
+                }
+
+                val registersSubstitution: Map<Register, FixedRegister> = usedSpills.zip(spareRegisters).toMap()
+
+                val instructionPrologue = readSpills.flatMap { loadSpillIntoReg(it, registersSubstitution[it]!!) }
+                val instructionEpilogue = writtenSpills.flatMap { saveRegIntoSpill(registersSubstitution[it]!!, it) }
+
+                instructionPrologue + listOf(instruction.substituteRegisters(registersSubstitution)) + instructionEpilogue
+            }
+
+        object : BasicBlock {
+            override fun label(): BlockLabel = block.label()
+
+            override fun instructions(): List<Instruction> = newInstructions
+
+            override fun successors(): Set<BasicBlock> = block.successors()
+
+            override fun predecessors(): Set<BasicBlock> = block.predecessors()
+        }
+    }
+}

--- a/src/main/kotlin/cacophony/controlflow/Variable.kt
+++ b/src/main/kotlin/cacophony/controlflow/Variable.kt
@@ -9,5 +9,7 @@ sealed class Variable {
 
     sealed class AuxVariable : Variable() {
         class StaticLinkVariable : AuxVariable()
+
+        class SpillVariable : AuxVariable()
     }
 }

--- a/src/main/kotlin/cacophony/controlflow/functions/FunctionHandlerImpl.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/FunctionHandlerImpl.kt
@@ -106,7 +106,6 @@ class FunctionHandlerImpl(
                 is Variable.SourceVariable -> {
                     analyzedFunction.variables.find { it.declaration == variable.definition }?.definedIn
                 }
-
                 is Variable.AuxVariable.StaticLinkVariable -> {
                     if (getStaticLink() == variable) {
                         function
@@ -114,12 +113,9 @@ class FunctionHandlerImpl(
                         ancestorFunctionHandlers.find { it.getStaticLink() == variable }?.getFunctionDeclaration()
                     }
                 }
-                // For whoever finds this place in the future because of compilation error after
-                // adding a new subtype of AuxVariable:
-                //   If generateVariableAccess should support the new type, implement new logic here.
-                //   If not, uncomment this else statement and add an appropriate unit test.
-                // else -> throw GenerateVariableAccessException(
-                //   "Cannot generate access to variables other than static links and source variables.")
+                else -> throw GenerateVariableAccessException(
+                    "Cannot generate access to variables other than static links and source variables.",
+                )
             }
 
         if (definedInDeclaration == null) {
@@ -157,7 +153,7 @@ class FunctionHandlerImpl(
 
     override fun getStaticLink(): Variable.AuxVariable.StaticLinkVariable = staticLink
 
-    public fun getStackSpace(): CFGNode.ConstantLazy = stackSpace
+    fun getStackSpace(): CFGNode.ConstantLazy = stackSpace
 
     private val resultRegister = Register.VirtualRegister()
 

--- a/src/main/kotlin/cacophony/pipeline/CacophonyLogger.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyLogger.kt
@@ -134,8 +134,7 @@ class CacophonyLogger : Logger<Int, TokenCategorySpecific, CacophonyGrammarSymbo
         println(programCfgToGraphviz(cfg))
     }
 
-    override fun logSuccessfulInstructionCovering(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>) {
-        println("Instruction covering successful :D")
+    private fun logCovering(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>) {
         covering.forEach { (function, blocks) ->
             println("  $function (${function.identifier}/${function.arguments.size})")
             blocks.forEach { block ->
@@ -145,6 +144,11 @@ class CacophonyLogger : Logger<Int, TokenCategorySpecific, CacophonyGrammarSymbo
                 }
             }
         }
+    }
+
+    override fun logSuccessfulInstructionCovering(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>) {
+        println("Instruction covering successful :D")
+        logCovering(covering)
     }
 
     override fun logSuccessfulLivenessGeneration(liveness: Map<Definition.FunctionDeclaration, Liveness>) {
@@ -163,6 +167,18 @@ class CacophonyLogger : Logger<Int, TokenCategorySpecific, CacophonyGrammarSymbo
                     println("          ${shortRegisterName(k)} -> ${v.map { shortRegisterName(it) }}")
             }
         }
+    }
+
+    override fun logSpillHandlingAttempt(spareRegisters: Set<Register.FixedRegister>) {
+        println(
+            "Some virtual registers have spilled. Attempting to handle spills using spare registers: [" +
+                spareRegisters.joinToString(", ") { shortRegisterName(it) } + "]",
+        )
+    }
+
+    override fun logSuccessfulSpillHandling(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>) {
+        println("Spill handling successful :D")
+        logCovering(covering)
     }
 
     override fun logSuccessfulAssembling(dest: Path) {

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -210,7 +210,7 @@ class CacophonyPipeline(
         return covering
     }
 
-    private fun analyzeLiveness(ast: AST): Map<FunctionDeclaration, Liveness> =
+    fun analyzeLiveness(ast: AST): Map<FunctionDeclaration, Liveness> =
         coverWithInstructions(ast).mapValues { (_, loweredCFG) -> cacophony.codegen.registers.analyzeLiveness(loweredCFG) }
 
     private fun analyzeLiveness(covering: Map<FunctionDeclaration, LoweredCFGFragment>): Map<FunctionDeclaration, Liveness> {
@@ -222,7 +222,7 @@ class CacophonyPipeline(
     fun allocateRegisters(ast: AST, allowedRegisters: Set<HardwareRegister> = allGPRs): Map<FunctionDeclaration, RegisterAllocation> =
         analyzeLiveness(ast).mapValues { (_, liveness) -> cacophony.codegen.registers.allocateRegisters(liveness, allowedRegisters) }
 
-    private fun allocateRegisters(
+    fun allocateRegisters(
         liveness: Map<FunctionDeclaration, Liveness>,
         allowedRegisters: Set<HardwareRegister> = allGPRs,
     ): Map<FunctionDeclaration, RegisterAllocation> {
@@ -296,7 +296,7 @@ class CacophonyPipeline(
         }
     }
 
-    private fun generateAsm(input: Input): Map<FunctionDeclaration, String> {
+    fun generateAsm(input: Input): Map<FunctionDeclaration, String> {
         val asm = generateAsm(generateAST(input))
         asm.forEach { (function, asm) -> println("$function generates asm:\n$asm") }
         return asm

--- a/src/main/kotlin/cacophony/pipeline/Logger.kt
+++ b/src/main/kotlin/cacophony/pipeline/Logger.kt
@@ -4,6 +4,7 @@ import cacophony.codegen.linearization.BasicBlock
 import cacophony.codegen.registers.Liveness
 import cacophony.codegen.registers.RegisterAllocation
 import cacophony.controlflow.CFGFragment
+import cacophony.controlflow.Register
 import cacophony.grammars.AnalyzedGrammar
 import cacophony.grammars.ParseTree
 import cacophony.semantic.analysis.*
@@ -58,6 +59,10 @@ interface Logger<StateT, TokenT : Enum<TokenT>, GrammarSymbol : Enum<GrammarSymb
     fun logSuccessfulInstructionCovering(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>)
 
     fun logSuccessfulLivenessGeneration(liveness: Map<Definition.FunctionDeclaration, Liveness>)
+
+    fun logSpillHandlingAttempt(spareRegisters: Set<Register.FixedRegister>)
+
+    fun logSuccessfulSpillHandling(covering: Map<Definition.FunctionDeclaration, List<BasicBlock>>)
 
     fun logSuccessfulAssembling(dest: Path)
 

--- a/src/test/kotlin/cacophony/codegen/registers/RegisterAllocationTest.kt
+++ b/src/test/kotlin/cacophony/codegen/registers/RegisterAllocationTest.kt
@@ -14,20 +14,6 @@ class RegisterAllocationTest {
         allocateRegisters(liveness, allowedRegisters).apply { validate(liveness, allowedRegisters) }
 
     @Test
-    fun `cannot allocate undeclared hardware register`() {
-        assertThatThrownBy {
-            allocateRegisters(
-                Liveness(
-                    setOf(Register.VirtualRegister(), Register.FixedRegister(HardwareRegister.RBX)),
-                    emptyMap(),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX),
-            )
-        }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
     fun `register cannot interfere with itself`() {
         assertThatThrownBy {
             val reg1 = Register.VirtualRegister()

--- a/src/test/kotlin/cacophony/codegen/registers/SpillHandlingTest.kt
+++ b/src/test/kotlin/cacophony/codegen/registers/SpillHandlingTest.kt
@@ -1,0 +1,402 @@
+package cacophony.codegen.registers
+
+import cacophony.codegen.instructions.Instruction
+import cacophony.codegen.instructions.InstructionCovering
+import cacophony.codegen.linearization.BasicBlock
+import cacophony.controlflow.CFGNode
+import cacophony.controlflow.HardwareRegister
+import cacophony.controlflow.Register
+import cacophony.controlflow.functions.FunctionHandler
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SpillHandlingTest {
+    private fun mockInstruction(def: Set<Register>, use: Set<Register>): Instruction {
+        val instruction = mockk<Instruction>()
+        every { instruction.registersRead } returns use
+        every { instruction.registersWritten } returns def
+        return instruction
+    }
+
+    private fun mockBlock(instructions: List<Instruction>): BasicBlock {
+        val block = mockk<BasicBlock>()
+        every { block.instructions() } returns instructions
+        return block
+    }
+
+    @Test
+    fun `generates proper prologue for instructions reading spilled registers`() {
+        // given
+        val spareReg1 = Register.FixedRegister(HardwareRegister.RAX)
+        val spareReg2 = Register.FixedRegister(HardwareRegister.RBX)
+        val spilledRegA = Register.VirtualRegister()
+        val spilledRegB = Register.VirtualRegister()
+
+        val spillSlotA = mockk<CFGNode.LValue>()
+        val spillSlotB = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlotA andThen spillSlotB
+
+        val prologueInstructionA = mockk<Instruction>()
+        val prologueInstructionB = mockk<Instruction>()
+        var capturedNode1: CFGNode? = null
+        var capturedNode2: CFGNode? = null
+        val capture = slot<CFGNode>()
+        val instructionCovering = mockk<InstructionCovering>()
+        every { instructionCovering.coverWithInstructions(capture(capture)) } answers {
+            capturedNode1 = capture.captured
+            listOf(prologueInstructionA)
+        } andThenAnswer {
+            capturedNode2 = capture.captured
+            listOf(prologueInstructionB)
+        }
+
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledRegA, spilledRegB))
+
+        val instruction = mockInstruction(setOf(), setOf(spilledRegA, spilledRegB))
+        val instructionWithSubRegisters = mockInstruction(setOf(), setOf(spareReg1, spareReg2))
+        every { instruction.substituteRegisters(any()) } returns instructionWithSubRegisters
+
+        val block = mockBlock(listOf(instruction))
+
+        // when
+        val adjustedLoweredCFG =
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg1, spareReg2),
+            )
+
+        // then
+        // assert mocks were called with proper params
+        assert(
+            capturedNode1 != null &&
+                capturedNode2 != null &&
+                capturedNode1 is CFGNode.Assignment &&
+                capturedNode2 is CFGNode.Assignment,
+        )
+        val dest1 = (capturedNode1 as CFGNode.Assignment).destination
+        val dest2 = (capturedNode2 as CFGNode.Assignment).destination
+        val val1 = (capturedNode1 as CFGNode.Assignment).value
+        val val2 = (capturedNode2 as CFGNode.Assignment).value
+
+        assertThat(listOf(dest1, dest2)).containsExactlyInAnyOrder(CFGNode.RegisterUse(spareReg1), CFGNode.RegisterUse(spareReg2))
+        assertThat(listOf(val1, val2)).containsExactlyInAnyOrder(spillSlotA, spillSlotB)
+
+        // assert the result is correct
+        assertThat(adjustedLoweredCFG).hasSize(1)
+        val newInstructions = adjustedLoweredCFG[0].instructions()
+        assertThat(newInstructions).hasSize(3)
+        assertThat(newInstructions[2]).isEqualTo(instructionWithSubRegisters)
+        assertThat(listOf(newInstructions[0], newInstructions[1])).containsExactlyInAnyOrder(
+            prologueInstructionA,
+            prologueInstructionB,
+        )
+    }
+
+    @Test
+    fun `generates proper epilogue for instruction writing spilled registers`() {
+        // given
+        val spareReg1 = Register.FixedRegister(HardwareRegister.RAX)
+        val spareReg2 = Register.FixedRegister(HardwareRegister.RBX)
+        val spilledRegA = Register.VirtualRegister()
+        val spilledRegB = Register.VirtualRegister()
+
+        val spillSlotA = mockk<CFGNode.LValue>()
+        val spillSlotB = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlotA andThen spillSlotB
+
+        val epilogueInstructionA = mockk<Instruction>()
+        val epilogueInstructionB = mockk<Instruction>()
+        var capturedNode1: CFGNode? = null
+        var capturedNode2: CFGNode? = null
+        val capture = slot<CFGNode>()
+        val instructionCovering = mockk<InstructionCovering>()
+        every { instructionCovering.coverWithInstructions(capture(capture)) } answers {
+            capturedNode1 = capture.captured
+            listOf(epilogueInstructionA)
+        } andThenAnswer {
+            capturedNode2 = capture.captured
+            listOf(epilogueInstructionB)
+        }
+
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledRegA, spilledRegB))
+
+        val instruction = mockInstruction(setOf(spilledRegA, spilledRegB), setOf())
+        val instructionWithSubRegisters = mockInstruction(setOf(spareReg1, spareReg2), setOf())
+        every { instruction.substituteRegisters(any()) } returns instructionWithSubRegisters
+
+        val block = mockBlock(listOf(instruction))
+
+        // when
+        val adjustedLoweredCFG =
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg1, spareReg2),
+            )
+
+        // then
+        // assert mocks were called with proper params
+        assert(
+            capturedNode1 != null &&
+                capturedNode2 != null &&
+                capturedNode1 is CFGNode.Assignment &&
+                capturedNode2 is CFGNode.Assignment,
+        )
+        val dest1 = (capturedNode1 as CFGNode.Assignment).destination
+        val dest2 = (capturedNode2 as CFGNode.Assignment).destination
+        val val1 = (capturedNode1 as CFGNode.Assignment).value
+        val val2 = (capturedNode2 as CFGNode.Assignment).value
+
+        assertThat(listOf(dest1, dest2)).containsExactlyInAnyOrder(spillSlotA, spillSlotB)
+        assertThat(listOf(val1, val2)).containsExactlyInAnyOrder(CFGNode.RegisterUse(spareReg1), CFGNode.RegisterUse(spareReg2))
+
+        // assert the result is correct
+        assertThat(adjustedLoweredCFG).hasSize(1)
+        val newInstructions = adjustedLoweredCFG[0].instructions()
+        assertThat(newInstructions).hasSize(3)
+        assertThat(newInstructions[0]).isEqualTo(instructionWithSubRegisters)
+        assertThat(listOf(newInstructions[1], newInstructions[2])).containsExactlyInAnyOrder(
+            epilogueInstructionA,
+            epilogueInstructionB,
+        )
+    }
+
+    @Test
+    fun `generates proper prologue and epilogue for instructions reading and writing spilled registers`() {
+        // given
+        val spareReg1 = Register.FixedRegister(HardwareRegister.RAX)
+        val spareReg2 = Register.FixedRegister(HardwareRegister.RBX)
+        val spilledRegA = Register.VirtualRegister()
+        val spilledRegB = Register.VirtualRegister()
+
+        val spillSlotA = mockk<CFGNode.LValue>()
+        val spillSlotB = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlotA andThen spillSlotB
+
+        val prologueInstruction = mockk<Instruction>()
+        val epilogueInstruction = mockk<Instruction>()
+        var capturedNode1: CFGNode? = null
+        var capturedNode2: CFGNode? = null
+        val capture = slot<CFGNode>()
+        val instructionCovering = mockk<InstructionCovering>()
+        every { instructionCovering.coverWithInstructions(capture(capture)) } answers {
+            capturedNode1 = capture.captured
+            listOf(prologueInstruction)
+        } andThenAnswer {
+            capturedNode2 = capture.captured
+            listOf(epilogueInstruction)
+        }
+
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledRegA, spilledRegB))
+
+        val instruction = mockInstruction(setOf(spilledRegA), setOf(spilledRegB))
+        val instructionWithSubRegisters = mockInstruction(setOf(), setOf())
+        every { instruction.substituteRegisters(any()) } returns instructionWithSubRegisters
+
+        val block = mockBlock(listOf(instruction))
+
+        // when
+        val adjustedLoweredCFG =
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg1, spareReg2),
+            )
+
+        // then
+        // assert mocks were called with proper params
+        assert(
+            capturedNode1 != null &&
+                capturedNode2 != null &&
+                capturedNode1 is CFGNode.Assignment &&
+                capturedNode2 is CFGNode.Assignment,
+        )
+        val dest1 = (capturedNode1 as CFGNode.Assignment).destination
+        val dest2 = (capturedNode2 as CFGNode.Assignment).destination
+        val val1 = (capturedNode1 as CFGNode.Assignment).value
+        val val2 = (capturedNode2 as CFGNode.Assignment).value
+
+        assertThat(listOf(val1, val2, dest1, dest2)).containsExactlyInAnyOrder(
+            spillSlotA,
+            spillSlotB,
+            CFGNode.RegisterUse(spareReg1),
+            CFGNode.RegisterUse(spareReg2),
+        )
+        assertThat(val1 == spillSlotB || val2 == spillSlotB)
+        assertThat(dest1 == spillSlotA || dest2 == spillSlotA)
+
+        // assert the result is correct
+        assertThat(adjustedLoweredCFG).hasSize(1)
+        val newInstructions = adjustedLoweredCFG[0].instructions()
+        assertThat(newInstructions).hasSize(3)
+        assertThat(newInstructions[0]).isEqualTo(prologueInstruction)
+        assertThat(newInstructions[1]).isEqualTo(instructionWithSubRegisters)
+        assertThat(newInstructions[2]).isEqualTo(epilogueInstruction)
+    }
+
+    @Test
+    fun `modifies all basic blocks with spilled registers`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val spilledReg = Register.VirtualRegister()
+
+        val spillSlot = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlot
+
+        val prologueInstruction = mockk<Instruction>()
+        val instructionCovering = mockk<InstructionCovering>()
+        every { instructionCovering.coverWithInstructions(any()) } returns listOf(prologueInstruction)
+
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledReg))
+
+        val instruction = mockInstruction(setOf(), setOf(spilledReg))
+        val instructionWithSubRegisters = mockInstruction(setOf(), setOf(spareReg))
+        every { instruction.substituteRegisters(any()) } returns instructionWithSubRegisters
+
+        val block = mockBlock(listOf(instruction))
+
+        // when
+        val adjustedLoweredCFG =
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block, block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+
+        // then
+        assertThat(adjustedLoweredCFG).hasSize(2)
+        assertThat(adjustedLoweredCFG[0].instructions()).isEqualTo(
+            adjustedLoweredCFG[1].instructions(),
+        )
+    }
+
+    @Test
+    fun `leaves basic blocks not using spilled registers unchanged`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val spilledReg = Register.VirtualRegister()
+
+        val spillSlot = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlot
+
+        val instructionCovering = mockk<InstructionCovering>()
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledReg))
+
+        val instruction = mockInstruction(setOf(), setOf())
+        every { instruction.substituteRegisters(any()) } returns instruction
+
+        val block = mockBlock(listOf(instruction))
+
+        // when
+        val adjustedLoweredCFG =
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+
+        // then
+        assertThat(adjustedLoweredCFG).hasSize(1)
+        assertThat(adjustedLoweredCFG[0].instructions()).isEqualTo(listOf(instruction))
+    }
+
+    @Test
+    fun `throws if spare register is used in provided register allocation`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val functionHandler = mockk<FunctionHandler>()
+        val instructionCovering = mockk<InstructionCovering>()
+        val registerAllocation = RegisterAllocation(mapOf(Register.VirtualRegister() to HardwareRegister.RAX), setOf())
+        val instruction = mockInstruction(setOf(), setOf())
+        val block = mockBlock(listOf(instruction))
+
+        // when & then
+        assertThrows<SpillHandlingException> {
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+        }
+    }
+
+    @Test
+    fun `throws if fixed register has spilled in register allocation`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val functionHandler = mockk<FunctionHandler>()
+        val instructionCovering = mockk<InstructionCovering>()
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spareReg))
+        val instruction = mockInstruction(setOf(), setOf())
+        val block = mockBlock(listOf(instruction))
+
+        // when & then
+        assertThrows<SpillHandlingException> {
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+        }
+    }
+
+    @Test
+    fun `throws if not enough spare registers have been provided`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val spilledRegA = Register.VirtualRegister()
+        val spilledRegB = Register.VirtualRegister()
+
+        val spillSlotA = mockk<CFGNode.LValue>()
+        val spillSlotB = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlotA andThen spillSlotB
+
+        val prologueInstructionA = mockk<Instruction>()
+        val prologueInstructionB = mockk<Instruction>()
+        val instructionCovering = mockk<InstructionCovering>()
+        every { instructionCovering.coverWithInstructions(any()) } returns listOf(prologueInstructionA) andThen
+            listOf(prologueInstructionB)
+
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledRegA, spilledRegB))
+
+        val instruction = mockInstruction(setOf(), setOf(spilledRegA, spilledRegB))
+        val instructionWithSubRegisters = mockInstruction(setOf(), setOf(spareReg))
+        every { instruction.substituteRegisters(any()) } returns instructionWithSubRegisters
+
+        val block = mockBlock(listOf(instruction))
+
+        // when & then
+        assertThrows<SpillHandlingException> {
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/cacophony/codegen/registers/SpillHandlingTest.kt
+++ b/src/test/kotlin/cacophony/codegen/registers/SpillHandlingTest.kt
@@ -363,6 +363,33 @@ class SpillHandlingTest {
     }
 
     @Test
+    fun `throws if encountered instruction with spills using one of spare registers`() {
+        // given
+        val spareReg = Register.FixedRegister(HardwareRegister.RAX)
+        val spilledReg = Register.VirtualRegister()
+
+        val spillSlot = mockk<CFGNode.LValue>()
+        val functionHandler = mockk<FunctionHandler>()
+        every { functionHandler.allocateFrameVariable(any()) } returns spillSlot
+
+        val instructionCovering = mockk<InstructionCovering>()
+        val registerAllocation = RegisterAllocation(mapOf(), setOf(spilledReg))
+        val instruction = mockInstruction(setOf(Register.FixedRegister(HardwareRegister.RAX)), setOf(spilledReg))
+        val block = mockBlock(listOf(instruction))
+
+        // when & then
+        assertThrows<SpillHandlingException> {
+            adjustLoweredCFGToHandleSpills(
+                instructionCovering,
+                functionHandler,
+                listOf(block),
+                registerAllocation,
+                setOf(spareReg),
+            )
+        }
+    }
+
+    @Test
     fun `throws if not enough spare registers have been provided`() {
         // given
         val spareReg = Register.FixedRegister(HardwareRegister.RAX)

--- a/src/test/kotlin/cacophony/controlflow/functions/FunctionHandlerTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/functions/FunctionHandlerTest.kt
@@ -978,5 +978,34 @@ class FunctionHandlerTest {
                 )
             }
         }
+
+        @Test
+        fun `throws if requested generation access of variable other than source variable or static link`() {
+            // given
+            val fDef =
+                Definition.FunctionDeclaration(
+                    mockRange,
+                    "f",
+                    null,
+                    emptyList(),
+                    Type.Basic(mockRange, "Int"),
+                    Literal.IntLiteral(mockRange, 42),
+                )
+            val fAnalyzed =
+                AnalyzedFunction(
+                    fDef,
+                    null,
+                    setOf(),
+                    mutableSetOf(),
+                    0,
+                    emptySet(),
+                )
+            val fHandler = makeDefaultHandler(fDef, fAnalyzed)
+
+            // when & then
+            org.junit.jupiter.api.assertThrows<GenerateVariableAccessException> {
+                fHandler.generateVariableAccess(Variable.AuxVariable.SpillVariable())
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #168 

High level idea is the following:

If register allocation fails with all GPRs, we try to allocate them again with all GPRs minus { R8, R9 } <- these are left for spill handling. The allocation should fail again with some spills

Now we adjust `LoweredCFGFragment` for every function:
- call `allocateFrameVariable()` for every spilled virtual register
- iterate over all instructions in basic blocks
- we detect instruction reading spilled register -> we add some instructions called `prologue` of this instruction, these instructions are responsible for loading spills from memory to registers R8 and R9. Then we substitute spilled registers in the function with R8 and R9,
- analogously, if we detect instruction writing to spilled registers -> we substitute registers in the instruction for R8 and R9 and add an `epilogue` - a list of instructions responsible for saving values of R8 and R9 into memory where spills are stored