### PR TITLE
Fix `return` with complex expression in CFG generation

### DIFF
--- a/src/main/kotlin/cacophony/controlflow/generation/CFGGenerator.kt
+++ b/src/main/kotlin/cacophony/controlflow/generation/CFGGenerator.kt
@@ -292,7 +292,16 @@ internal class CFGGenerator(
         // Similarly to break, return creates an artificial exit
         val artificialExit = cfg.addUnconditionalVertex(CFGNode.NoOp)
 
-        return SubCFG.Extracted(resultAssignmentVertex, artificialExit, CFGNode.NoOp)
+        val entry =
+            when (valueCFG) {
+                is SubCFG.Extracted -> {
+                    valueCFG.exit.connect(resultAssignmentVertex.label)
+                    valueCFG.entry
+                }
+                is SubCFG.Immediate -> resultAssignmentVertex
+            }
+
+        return SubCFG.Extracted(entry, artificialExit, CFGNode.NoOp)
     }
 
     private fun visitWhileStatement(expression: Statement.WhileStatement, mode: EvalMode, context: Context): SubCFG {


### PR DESCRIPTION
The computation of subexpression was not linked to the remaining part of the CFG
This is hopefully fixed now