### PR TITLE
Add special sideEffect pattern for spills

### DIFF
--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -326,11 +326,12 @@ object MemoryByRegisterWithSubtractionToRegisterAssignment : SideEffectPattern {
     private val rhsRegister = RegisterLabel()
 
     private val lhsSlot = CFGNode.RegisterSlot(lhsRegister)
-    private val rhsSlot = memoryAccess(
-         CFGNode.RegisterSlot(rhsRegister)
-            sub
-            CFGNode.ConstantSlot(displacementLabel) { true }
-    )
+    private val rhsSlot =
+        memoryAccess(
+            CFGNode.RegisterSlot(rhsRegister)
+                sub
+                CFGNode.ConstantSlot(displacementLabel) { true },
+        )
     override val tree = lhsSlot assign rhsSlot
 
     override fun makeInstance(fill: SlotFill) =

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -34,6 +34,7 @@ val sideEffectPatterns =
         RegisterToMemoryAssignmentPattern,
         MemoryAssignmentPattern,
         MemoryToRegisterAssignmentPattern,
+        MemoryByRegisterWithSubtractionToRegisterAssignment,
     )
 
 object NoOpPattern : SideEffectPattern {
@@ -316,5 +317,24 @@ object RegisterToMemoryWithSubtractedDisplacementAssignmentPattern : SideEffectP
     override fun makeInstance(fill: SlotFill) =
         instructions(fill) {
             mov(memWithDisplacement(reg(lhsLabel), -const(displacementLabel)), reg(rhsLabel))
+        }
+}
+
+object MemoryByRegisterWithSubtractionToRegisterAssignment : SideEffectPattern {
+    private val lhsRegister = RegisterLabel()
+    private val displacementLabel = ConstantLabel()
+    private val rhsRegister = RegisterLabel()
+
+    private val lhsSlot = CFGNode.RegisterSlot(lhsRegister)
+    private val rhsSlot = memoryAccess(
+         CFGNode.RegisterSlot(rhsRegister)
+            sub
+            CFGNode.ConstantSlot(displacementLabel) { true }
+    )
+    override val tree = lhsSlot assign rhsSlot
+
+    override fun makeInstance(fill: SlotFill) =
+        instructions(fill) {
+            mov(reg(lhsRegister), memWithDisplacement(reg(rhsRegister), -const(displacementLabel)))
         }
 }


### PR DESCRIPTION
Special pattern, so that spills handling doesn't create new virtual registers.