### PR TITLE
optimize stack allocation for spills

### DIFF
--- a/src/main/kotlin/cacophony/automata/minimization/Utils.kt
+++ b/src/main/kotlin/cacophony/automata/minimization/Utils.kt
@@ -2,7 +2,7 @@ package cacophony.automata.minimization
 
 import cacophony.automata.DFA
 import cacophony.automata.SimpleDFA
-import cacophony.utils.getReachableFrom
+import cacophony.graphs.getReachableFrom
 
 class DFAPreimagesCalculator<StateT, AtomT>(
     dfa: DFA<StateT, AtomT, *>,

--- a/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
+++ b/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
@@ -127,6 +127,7 @@ private fun colorSpills(
                 .getOrDefault(v, setOf())
                 .filterIsInstance<VirtualRegister>()
                 .filter { u -> spills.contains(u) }
+                .toSet()
         }
     val spillsCopying =
         spills.associateWith { v ->
@@ -134,6 +135,7 @@ private fun colorSpills(
                 .getOrDefault(v, setOf())
                 .filterIsInstance<VirtualRegister>()
                 .filter { u -> spills.contains(u) }
+                .toSet()
         }
 
     val spillsColoring =

--- a/src/main/kotlin/cacophony/controlflow/generation/CFG.kt
+++ b/src/main/kotlin/cacophony/controlflow/generation/CFG.kt
@@ -3,7 +3,7 @@ package cacophony.controlflow.generation
 import cacophony.controlflow.CFGFragment
 import cacophony.controlflow.CFGLabel
 import cacophony.controlflow.CFGNode
-import cacophony.utils.getReachableFrom
+import cacophony.graphs.getReachableFrom
 
 /**
  * Internal mutable representation of CFG that is being built

--- a/src/main/kotlin/cacophony/grammars/FindFirst.kt
+++ b/src/main/kotlin/cacophony/grammars/FindFirst.kt
@@ -1,7 +1,7 @@
 package cacophony.grammars
 
 import cacophony.automata.DFA
-import cacophony.utils.getProperTransitiveClosure
+import cacophony.graphs.getProperTransitiveClosure
 
 data class GeneralizedSymbol<StateT, SymbolT, ResultT>(
     val state: DFAStateReference<StateT, SymbolT, ResultT>?,

--- a/src/main/kotlin/cacophony/graphs/FirstFitGraphColoring.kt
+++ b/src/main/kotlin/cacophony/graphs/FirstFitGraphColoring.kt
@@ -1,0 +1,145 @@
+package cacophony.graphs
+
+import cacophony.controlflow.Register
+
+class FirstFitColoringException(reason: String) : Exception(reason)
+
+/**
+ * Assumes that keys of graph map are exactly all vertices in graph.
+ * @throws FirstFitColoringException if graphs contains loops.
+ */
+class FirstFitGraphColoring<VertexT, ColorT> : GraphColoring<VertexT, ColorT> {
+    override fun doColor(
+        graph: Map<VertexT, Collection<VertexT>>,
+        coalesce: Map<VertexT, Collection<VertexT>>,
+        fixedColors: Map<VertexT, ColorT>,
+        allowedColors: Collection<ColorT>,
+    ): Map<VertexT, ColorT> = ColoringProblemInstance(graph, coalesce, fixedColors, allowedColors).doColor()
+
+    private class ColoringProblemInstance<VertexT, ColorT>(
+        graph: Map<VertexT, Collection<VertexT>>,
+        coalesce: Map<VertexT, Collection<VertexT>>,
+        private val fixedColors: Map<VertexT, ColorT>,
+        private val allowedColors: Collection<ColorT>,
+    ) {
+        init {
+            // Verify there are no loops in graph.
+            if (graph.any { it.value.contains(it.key) }) {
+                throw FirstFitColoringException("Cannot color graph with loops.")
+            }
+        }
+
+        private val originalGraph = getSymmetricClosure(graph).mapValues { (_, neigh) -> neigh.toMutableSet() }
+        private val copying = getProperTransitiveSymmetricClosure(coalesce)
+        private val vertices = originalGraph.keys.toMutableSet()
+
+        private fun originalNeighbors(v: VertexT) = originalGraph.getOrDefault(v, emptySet())
+
+        private fun copies(v: VertexT) = (copying.getOrDefault(v, emptySet())).filter { it in vertices }
+
+        init {
+            // Add graph edges between vertices with different fixed colors.
+            vertices.forEach { v ->
+                vertices.forEach { u ->
+                    if (fixedColors.containsKey(v) && fixedColors.containsKey(u) && fixedColors[v] != fixedColors[u]) {
+                        originalGraph[v]!!.add(u)
+                        originalGraph[u]!!.add(v)
+                    }
+                }
+            }
+        }
+
+        // Deep copy of originalGraph.
+        private val currentGraph = originalGraph.keys.associateWith { originalGraph[it]!!.toMutableSet() }.toMutableMap()
+
+        private val stack = mutableListOf<Set<VertexT>>()
+        private val copyGroups = mutableMapOf<VertexT, Set<VertexT>>()
+
+        private fun neighbors(v: VertexT) = currentGraph.getOrDefault(v, emptySet())
+
+        private fun copyGroup(v: VertexT) = (copyGroups.getOrDefault(v, emptySet())) + setOf(v)
+
+        private fun deposit(v: VertexT) {
+            stack.add(copyGroup(v))
+            vertices.removeAll(copyGroup(v))
+            currentGraph[v]?.forEach {
+                currentGraph[it]?.remove(v)
+            }
+        }
+
+        private fun coalesce(v: VertexT, u: VertexT) {
+            copyGroups[v] = copyGroup(v) + copyGroup(u)
+            vertices.remove(u)
+            currentGraph[u]?.forEach {
+                currentGraph[it]?.remove(u)
+                currentGraph[it]?.add(v)
+            }
+            currentGraph.getOrPut(v) { mutableSetOf() }.addAll(currentGraph[u] ?: emptySet())
+        }
+
+        // Uses George criterion for safety
+        private fun isCoalesceSafe(v: VertexT, u: VertexT): Boolean =
+            neighbors(v).all {
+                it in neighbors(u) ||
+                    neighbors(it).size < allowedColors.size
+            }
+
+        private fun shouldCoalesce(v: VertexT, u: VertexT): Boolean =
+            u !in neighbors(v) &&
+                u in copies(v) &&
+                isCoalesceSafe(v, u)
+
+        private fun vertexToCoalesce(v: VertexT) = copies(v).find { shouldCoalesce(v, it) }
+
+        private fun generateFirstFitOrder() {
+            while (vertices.isNotEmpty()) {
+                while (true) {
+                    val y =
+                        vertices
+                            .map { it to vertexToCoalesce(it) }
+                            .firstOrNull { it.second != null }
+                            ?.also { (a, b) -> coalesce(a, b!!) }
+                    if (y != null) continue
+
+                    val x = vertices.find { neighbors(it).size < allowedColors.size && vertexToCoalesce(it) == null }?.also { deposit(it) }
+                    if (x == null) break
+                }
+                if (vertices.isNotEmpty())
+                    deposit(vertices.minBy { if (it is Register.FixedRegister) Int.MAX_VALUE else neighbors(it).size })
+            }
+        }
+
+        fun doColor(): Map<VertexT, ColorT> {
+            generateFirstFitOrder()
+
+            val coloring = mutableMapOf<VertexT, ColorT>()
+
+            stack.forEach { group ->
+                val vertexWithFixedColor = group.find { fixedColors.containsKey(it) }
+                if (vertexWithFixedColor != null) {
+                    group.forEach {
+                        coloring[it] = fixedColors[vertexWithFixedColor]!!
+                    }
+                }
+            }
+
+            stack
+                .reversed()
+                .filter { !coloring.containsKey(it.first()) }
+                .forEach { group ->
+                    val forbiddenColors =
+                        group
+                            .map { v ->
+                                originalNeighbors(v).mapNotNull { coloring[it] }
+                            }.flatten()
+                            .toSet()
+                    val color = (allowedColors - forbiddenColors).firstOrNull()
+                    if (color != null) {
+                        group.forEach { coloring[it] = color }
+                    }
+                }
+
+            return coloring
+        }
+    }
+}

--- a/src/main/kotlin/cacophony/graphs/GraphColoring.kt
+++ b/src/main/kotlin/cacophony/graphs/GraphColoring.kt
@@ -1,0 +1,10 @@
+package cacophony.graphs
+
+interface GraphColoring<VertexT, ColorT> {
+    fun doColor(
+        graph: Map<VertexT, Collection<VertexT>>,
+        coalesce: Map<VertexT, Collection<VertexT>>,
+        fixedColors: Map<VertexT, ColorT>,
+        allowedColors: Collection<ColorT>,
+    ): Map<VertexT, ColorT>
+}

--- a/src/main/kotlin/cacophony/graphs/Utils.kt
+++ b/src/main/kotlin/cacophony/graphs/Utils.kt
@@ -1,4 +1,4 @@
-package cacophony.utils
+package cacophony.graphs
 
 import kotlin.math.min
 
@@ -48,6 +48,19 @@ fun <VertexT> getProperTransitiveClosure(graph: Map<VertexT, Collection<VertexT>
         component.forEach { closure[it] = reachable }
     }
     return closure
+}
+
+fun <VertexT> getSymmetricClosure(graph: Map<VertexT, Collection<VertexT>>): Map<VertexT, Set<VertexT>> {
+    val result = graph.mapValues { (_, v) -> v.toMutableSet() }.toMutableMap()
+    graph.forEach { (k, v) ->
+        v.forEach { result.getOrPut(it) { mutableSetOf() }.add(k) }
+    }
+    return result
+}
+
+fun <VertexT> getProperTransitiveSymmetricClosure(graph: Map<VertexT, Collection<VertexT>>): Map<VertexT, Set<VertexT>> {
+    val symmetric = getSymmetricClosure(graph)
+    return getTransitiveClosure(symmetric).mapValues { (k, v) -> v - setOf(k) }
 }
 
 // Returns a list of strongly connected components of a graph in a reverse topological order.

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -246,7 +246,7 @@ class CacophonyPipeline(
     ): Pair<
         Map<FunctionDeclaration, LoweredCFGFragment>,
         Map<FunctionDeclaration, RegisterAllocation>,
-    > {
+        > {
         if (registerAllocation.values.all { it.spills.isEmpty() }) {
             return covering to registerAllocation
         }

--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -18,6 +18,7 @@ import cacophony.controlflow.generation.ProgramCFG
 import cacophony.controlflow.generation.generateCFG
 import cacophony.diagnostics.Diagnostics
 import cacophony.grammars.ParseTree
+import cacophony.graphs.FirstFitGraphColoring
 import cacophony.lexer.CacophonyLexer
 import cacophony.parser.CacophonyGrammarSymbol
 import cacophony.parser.CacophonyParser
@@ -245,7 +246,7 @@ class CacophonyPipeline(
     ): Pair<
         Map<FunctionDeclaration, LoweredCFGFragment>,
         Map<FunctionDeclaration, RegisterAllocation>,
-        > {
+    > {
         if (registerAllocation.values.all { it.spills.isEmpty() }) {
             return covering to registerAllocation
         }
@@ -268,8 +269,10 @@ class CacophonyPipeline(
                             instructionCovering,
                             functionHandlers[functionDeclaration]!!,
                             loweredCfg,
+                            liveness[functionDeclaration]!!,
                             newRegisterAllocation[functionDeclaration]!!,
                             spareRegisters,
+                            FirstFitGraphColoring(),
                         )
                 }.toMap()
 

--- a/src/test/kotlin/cacophony/codegen/registers/RegisterAllocationTest.kt
+++ b/src/test/kotlin/cacophony/codegen/registers/RegisterAllocationTest.kt
@@ -2,437 +2,107 @@ package cacophony.codegen.registers
 
 import cacophony.controlflow.HardwareRegister
 import cacophony.controlflow.Register
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
+import cacophony.graphs.GraphColoring
+import io.mockk.*
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
-import kotlin.random.Random
+import org.junit.jupiter.api.assertThrows
 
 class RegisterAllocationTest {
-    private fun allocateAndValidate(liveness: Liveness, allowedRegisters: Set<HardwareRegister>): RegisterAllocation =
-        allocateRegisters(liveness, allowedRegisters).apply { validate(liveness, allowedRegisters) }
-
     @Test
-    fun `register cannot interfere with itself`() {
-        assertThatThrownBy {
-            val reg1 = Register.VirtualRegister()
-            val reg2 = Register.VirtualRegister()
-            allocateRegisters(
-                Liveness(
-                    setOf(reg1, reg2),
-                    mapOf(reg1 to setOf(reg1, reg2), reg2 to setOf(reg1, reg2)),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX),
-            )
-        }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
-    fun `unknown register as interference key`() {
-        assertThatThrownBy {
-            val known = setOf(Register.VirtualRegister())
-            allocateRegisters(
-                Liveness(
-                    known,
-                    mapOf(Register.VirtualRegister() to emptySet()),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX),
-            )
-        }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
-    fun `unknown register in copying map`() {
-        assertThatThrownBy {
-            val known = setOf(Register.VirtualRegister())
-            allocateRegisters(
-                Liveness(
-                    known,
-                    emptyMap(),
-                    mapOf(known.first() to setOf(Register.VirtualRegister())),
-                ),
-                setOf(HardwareRegister.RAX),
-            )
-        }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
-    fun `0 registers with 0 colors`() {
-        allocateAndValidate(
-            Liveness(
-                emptySet(),
-                emptyMap(),
-                emptyMap(),
-            ),
-            setOf(),
-        )
-    }
-
-    @Test
-    fun `1 register is enough if there are no interferences`() {
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    (1..50).map { Register.VirtualRegister() }.toSet(),
-                    emptyMap(),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RBP),
-            )
-
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `2 registers with copy are colored properly`() {
-        val regA = Register.VirtualRegister()
-        val regB = Register.VirtualRegister()
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(regA, regB),
-                    emptyMap(),
-                    mapOf(regA to setOf(regB), regB to setOf(regA)),
-                ),
-                setOf(HardwareRegister.RBP),
-            )
-
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `2 registers with copy are colored with the same color`() {
-        val regA = Register.VirtualRegister()
-        val regB = Register.VirtualRegister()
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(regA, regB),
-                    emptyMap(),
-                    mapOf(regA to setOf(regB), regB to setOf(regA)),
-                ),
-                setOf(HardwareRegister.RBP, HardwareRegister.RSP),
-            )
-
-        assertThat(allocation.spills).isEmpty()
-        assertThat(allocation.successful[regA]!!).isEqualTo(allocation.successful[regB]!!)
-    }
-
-    @Test
-    fun `2 fixed registers are colored properly`() {
-        val regB = Register.FixedRegister(HardwareRegister.RBX)
-        val regC = Register.FixedRegister(HardwareRegister.RCX)
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(regB, regC),
-                    emptyMap(),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX, HardwareRegister.RCX),
-            )
-
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `16 clique is 16 colorable`() {
-        val hwRegisters = HardwareRegister.entries.toSet()
-        val registers = hwRegisters.map { Register.VirtualRegister() }.toSet()
-
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers,
-                    registers.associateWith { registers subtract setOf(it) },
-                    emptyMap(),
-                ),
-                hwRegisters,
-            )
-
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `interference takes priority over copying`() {
-        val regA = Register.VirtualRegister()
-        val regB = Register.VirtualRegister()
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(regA, regB),
-                    mapOf(regA to setOf(regB), regB to setOf(regA)),
-                    mapOf(regA to setOf(regB)),
-                ),
-                setOf(HardwareRegister.RAX),
-            )
-        assertThat(allocation.spills).hasSize(1)
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = [5, 7, 21])
-    fun `4 clique blowup`(n: Int) {
-        val registers = (0..<n).map { Register.VirtualRegister() }
-        val interferences = mutableMapOf<Register, MutableSet<Register>>()
-        for (i in 0..<n) {
-            for (j in 0..<n) {
-                if (i % 4 != j % 4)
-                    interferences.getOrPut(registers[i]) { mutableSetOf() }.add(registers[j])
-            }
-        }
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers.toSet(),
-                    interferences,
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX, HardwareRegister.RCX),
-            )
-        assertThat(allocation.spills).hasSize(n / 4)
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = [4, 8, 20])
-    fun `clique with 3 available colors`(n: Int) {
-        val registers = (0..<n).map { Register.VirtualRegister() }
-        val interferences = mutableMapOf<Register, MutableSet<Register>>()
-        for (i in 0..<n) {
-            for (j in 0..<n) {
-                if (i != j) {
-                    interferences.getOrPut(registers[i]) { mutableSetOf() }.add(registers[j])
-                }
-            }
-        }
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers.toSet(),
-                    interferences,
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX, HardwareRegister.RCX),
-            )
-        assertThat(allocation.spills).hasSize(n - 3)
-    }
-
-    @Test
-    fun `copying chain with interference link`() {
-        val registers = (0..4).map { Register.VirtualRegister() }
-        val interferences = mapOf(registers[1] to setOf(registers[3]), registers[3] to setOf(registers[1]))
-        val copying = (1..4).associate { registers[it] to setOf(registers[it - 1]) }
-        allocateAndValidate(
-            Liveness(
-                registers.toSet(),
-                interferences.toMap(),
-                copying.toMap(),
-            ),
-            setOf(HardwareRegister.RAX),
-        )
-    }
-
-    @Test
-    fun `copying chain with fixed registers`() {
-        val registers =
-            listOf(
-                Register.VirtualRegister(),
-                Register.FixedRegister(HardwareRegister.RAX),
-                Register.VirtualRegister(),
-                Register.FixedRegister(HardwareRegister.RBX),
-                Register.VirtualRegister(),
-            )
-        val copying = (1..<registers.size).associate { registers[it] to setOf(registers[it - 1]) }
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers.toSet(),
-                    emptyMap(),
-                    copying,
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
-            )
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `bipartite clique`() {
-        val registers = (0..<20).map { Register.VirtualRegister() }
-        val interferences =
-            (0..<20).map { i ->
-                registers[i] to
-                    (0..<20)
-                        .filter {
-                            i / 10 != it / 10
-                        }.map { registers[it] }
-                        .toSet()
-            }
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers.toSet(),
-                    interferences.toMap(),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
-            )
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = [1, 2, 3, 4, 5, 6])
-    fun `half of bipartite clique`(seed: Int) {
-        val n = 20
-        val rnd = Random(seed)
-        val registers = (0..<n).map { Register.VirtualRegister() }.shuffled(rnd)
-        val interferences = registers.associateWith { mutableSetOf<Register>() }
-        for (i in 0..<n / 2) {
-            for (j in n / 2..<n) {
-                if (rnd.nextBoolean()) {
-                    interferences[registers[i]]!!.add(registers[j])
-                    interferences[registers[j]]!!.add(registers[i])
-                }
-            }
-        }
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    registers.toSet(),
-                    interferences.toMap(),
-                    emptyMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
-            )
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `tree of copies`() {
-        val reg = (1..7).map { Register.VirtualRegister() }
-        val interferences = reg.associateWith { mutableSetOf<Register>() }
-        val copy = reg.associateWith { mutableSetOf<Register>() }
-        interferences[reg[1]]!!.add(reg[2])
-        interferences[reg[2]]!!.add(reg[1])
-        interferences[reg[3]]!!.add(reg[4])
-        interferences[reg[4]]!!.add(reg[3])
-        interferences[reg[5]]!!.add(reg[6])
-        interferences[reg[6]]!!.add(reg[5])
-        copy[reg[1]]!!.add(reg[0])
-        copy[reg[2]]!!.add(reg[0])
-        copy[reg[3]]!!.add(reg[1])
-        copy[reg[4]]!!.add(reg[1])
-        copy[reg[5]]!!.add(reg[2])
-        copy[reg[6]]!!.add(reg[2])
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    reg.toSet(),
-                    interferences.toMap(),
-                    copy.toMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX, HardwareRegister.RCX),
-            )
-        assertThat(allocation.spills).isEmpty()
-    }
-
-    @Test
-    fun `bipartite clique with some copies`() {
-        val reg = (0..8).map { Register.VirtualRegister() }
-        val interferences = reg.associateWith { setOf<Register>() }.toMutableMap()
-        val copy = reg.associateWith { mutableSetOf<Register>() }
-
-        val a = (0..2).map { reg[it] }.toSet()
-        val b = (3..5).map { reg[it] }.toSet()
-        a.forEach { interferences[it] = b }
-        b.forEach { interferences[it] = a }
-        copy[reg[6]]!!.add(reg[0])
-        copy[reg[7]]!!.add(reg[5])
-        copy[reg[8]]!!.add(reg[1])
-
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    reg.toSet(),
-                    interferences.toMap(),
-                    copy.toMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
-            )
-
-        assertThat(allocation.spills).isEmpty()
-        assertThat(allocation.successful[reg[6]]).isEqualTo(allocation.successful[reg[0]])
-        assertThat(allocation.successful[reg[7]]).isEqualTo(allocation.successful[reg[3]])
-        assertThat(allocation.successful[reg[8]]).isEqualTo(allocation.successful[reg[0]])
-    }
-
-    @Test
-    fun `copying with fixed registers`() {
-        val rax = Register.FixedRegister(HardwareRegister.RAX)
-        val rbx = Register.FixedRegister(HardwareRegister.RBX)
-        val reg1 = Register.VirtualRegister()
-        val reg2 = Register.VirtualRegister()
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(rax, rbx, reg1, reg2),
-                    emptyMap(),
-                    mapOf(rax to setOf(reg2), reg1 to setOf(rbx)),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
-            )
-        assertThat(allocation.spills).isEmpty()
-        assertThat(allocation.successful[rax]).isEqualTo(HardwareRegister.RAX)
-        assertThat(allocation.successful[rbx]).isEqualTo(HardwareRegister.RBX)
-    }
-
-    @Test
-    fun `two copies with interference`() {
+    fun `calls graph coloring with proper parameters`() {
+        // given
+        val reg0 = Register.VirtualRegister()
         val reg1 = Register.VirtualRegister()
         val reg2 = Register.VirtualRegister()
         val reg3 = Register.VirtualRegister()
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    setOf(reg1, reg2, reg3),
-                    mapOf(reg2 to setOf(reg3), reg3 to setOf(reg2)),
-                    mapOf(reg1 to setOf(reg2), reg3 to setOf(reg1)),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX, HardwareRegister.RCX),
+        val reg4 = Register.FixedRegister(HardwareRegister.RBX)
+        val liveness =
+            Liveness(
+                setOf(reg0, reg1, reg2, reg3, reg4),
+                mapOf(reg0 to setOf(reg1)),
+                mapOf(reg2 to setOf(reg1)),
             )
-        assertThat(allocation.spills).isEmpty()
-        assertThat(allocation.successful[reg1]).isIn(allocation.successful[reg2], allocation.successful[reg3])
+
+        val graphColoring = mockk<GraphColoring<Register, HardwareRegister>>()
+        every { graphColoring.doColor(any(), any(), any(), any()) } returns mapOf()
+
+        val registerAllocator =
+            RegisterAllocator(
+                liveness,
+                setOf(HardwareRegister.RAX),
+                graphColoring,
+            )
+
+        // when
+        registerAllocator.allocate()
+
+        // then
+        verify {
+            graphColoring.doColor(
+                mapOf(reg0 to setOf(reg1), reg1 to setOf(), reg2 to setOf(), reg3 to setOf(), reg4 to setOf()),
+                mapOf(reg2 to setOf(reg1)),
+                mapOf(reg4 to HardwareRegister.RBX),
+                setOf(HardwareRegister.RAX),
+            )
+        }
     }
 
     @Test
-    fun `bipartite clique with some copies and fixed register`() {
-        val reg = (0..8).map { Register.VirtualRegister() }.toMutableList<Register>()
-        reg[6] = Register.FixedRegister(HardwareRegister.RBX)
-        val interferences = reg.associateWith { setOf<Register>() }.toMutableMap()
-        val copy = reg.associateWith { mutableSetOf<Register>() }
-
-        val a = (0..2).map { reg[it] }.toSet()
-        val b = (3..5).map { reg[it] }.toSet()
-        a.forEach { interferences[it] = b }
-        b.forEach { interferences[it] = a }
-        copy[reg[6]]!!.add(reg[0])
-        copy[reg[7]]!!.add(reg[5])
-        copy[reg[8]]!!.add(reg[1])
-
-        val allocation =
-            allocateAndValidate(
-                Liveness(
-                    reg.toSet(),
-                    interferences.toMap(),
-                    copy.toMap(),
-                ),
-                setOf(HardwareRegister.RAX, HardwareRegister.RBX),
+    fun `throws if register interferes with itself`() {
+        // given
+        val reg1 = Register.VirtualRegister()
+        val reg2 = Register.VirtualRegister()
+        val liveness =
+            Liveness(
+                setOf(reg1, reg2),
+                mapOf(reg1 to setOf(reg1, reg2), reg2 to setOf(reg1, reg2)),
+                emptyMap(),
             )
+        val graphColoring = mockk<GraphColoring<Register, HardwareRegister>>()
 
-        assertThat(allocation.spills).isEmpty()
-        assertThat(allocation.successful[reg[6]]).isEqualTo(allocation.successful[reg[0]])
-        assertThat(allocation.successful[reg[7]]).isEqualTo(allocation.successful[reg[3]])
-        assertThat(allocation.successful[reg[8]]).isEqualTo(allocation.successful[reg[0]])
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RegisterAllocator(liveness, setOf(HardwareRegister.RAX), graphColoring)
+        }
+    }
+
+    @Test
+    fun `throws if unknown register as interference key`() {
+        // given
+        val known = setOf(Register.VirtualRegister())
+        val liveness =
+            Liveness(
+                known,
+                mapOf(Register.VirtualRegister() to emptySet()),
+                emptyMap(),
+            )
+        val graphColoring = mockk<GraphColoring<Register, HardwareRegister>>()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RegisterAllocator(
+                liveness,
+                setOf(HardwareRegister.RAX),
+                graphColoring,
+            )
+        }
+    }
+
+    @Test
+    fun `throws if unknown register in copying map`() {
+        // given
+        val known = setOf(Register.VirtualRegister())
+        val liveness =
+            Liveness(
+                known,
+                emptyMap(),
+                mapOf(known.first() to setOf(Register.VirtualRegister())),
+            )
+        val graphColoring = mockk<GraphColoring<Register, HardwareRegister>>()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RegisterAllocator(liveness, setOf(HardwareRegister.RAX), graphColoring)
+        }
     }
 }

--- a/src/test/kotlin/cacophony/graphs/FirstFitGraphColoringTest.kt
+++ b/src/test/kotlin/cacophony/graphs/FirstFitGraphColoringTest.kt
@@ -1,0 +1,551 @@
+package cacophony.graphs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.random.Random
+
+class FirstFitGraphColoringTest {
+    private fun validateFixedColorsAreRespected(fixedColors: Map<Int, Int>, coloring: Map<Int, Int>) {
+        fixedColors.forEach { (v, c) ->
+            assertThat(coloring).containsKey(v)
+            assertThat(coloring[v]).isEqualTo(c)
+        }
+    }
+
+    private fun validateColoringUsesAllowedColors(fixedColors: Map<Int, Int>, allowedColors: Collection<Int>, coloring: Map<Int, Int>) {
+        coloring.forEach { (v, c) ->
+            if (!fixedColors.containsKey(v)) {
+                assertThat(allowedColors).contains(c)
+            }
+        }
+    }
+
+    private fun validateColoringIsProper(graph: Map<Int, Collection<Int>>, coloring: Map<Int, Int>) {
+        graph.forEach { (v, neigh) ->
+            neigh.forEach { u ->
+                if (coloring.containsKey(v) && coloring.containsKey(u)) {
+                    assertThat(coloring[v]).isNotEqualTo(coloring[u])
+                }
+            }
+        }
+    }
+
+    private fun validateColoring(
+        graph: Map<Int, Collection<Int>>,
+        fixedColors: Map<Int, Int>,
+        allowedColors: Collection<Int>,
+        coloring: Map<Int, Int>,
+    ) {
+        validateFixedColorsAreRespected(fixedColors, coloring)
+        validateColoringUsesAllowedColors(fixedColors, allowedColors, coloring)
+        validateColoringIsProper(graph, coloring)
+    }
+
+    @Test
+    fun `throws if graph contains loops`() {
+        // given & when & then
+        org.junit.jupiter.api.assertThrows<FirstFitColoringException> {
+            FirstFitGraphColoring<Int, Int>().doColor(
+                mapOf(0 to setOf(0)),
+                mapOf(),
+                mapOf(),
+                setOf(),
+            )
+        }
+    }
+
+    @Test
+    fun `properly colors empty graph with 0 available colors`() {
+        // given
+        val graph = mapOf<Int, Set<Int>>()
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf<Int>()
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring).isEmpty()
+    }
+
+    @Test
+    fun `properly colors with 1 register if there are no interferences`() {
+        // given
+        val graph = (1..50).associateWith { emptySet<Int>() }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring).containsExactlyInAnyOrderEntriesOf((1..50).associateWith { 0 })
+    }
+
+    @Test
+    fun `2 vertices in coalesce relation are colored properly`() {
+        // given
+        val graph = mapOf<Int, Set<Int>>(0 to emptySet(), 1 to emptySet())
+        val coalesce = mapOf(0 to setOf(1))
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                0 to 0,
+                1 to 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `2 vertices with copy are colored with the same color`() {
+        // given
+        val graph = mapOf<Int, Set<Int>>(0 to emptySet(), 1 to emptySet())
+        val coalesce = mapOf(0 to setOf(1))
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1)
+        assertThat(coloring[0]).isEqualTo(coloring[1])
+    }
+
+    @Test
+    fun `2 vertices with fixed colors are colored accordingly even if their colors are not in allowed colors`() {
+        // given
+        val graph = mapOf<Int, Set<Int>>(0 to emptySet(), 1 to emptySet())
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf(0 to 2, 1 to 3)
+        val allowedColors = setOf<Int>()
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                0 to 2,
+                1 to 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `16 clique is 16 colorable`() {
+        // given
+        val graph = (0..15).associateWith { (0..15).minus(it) }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = (0..15).toSet()
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrderElementsOf(0..15)
+    }
+
+    @Test
+    fun `interference takes priority over copying`() {
+        // given
+        val graph = mapOf(0 to setOf(1), 1 to setOf(0))
+        val coalesce = mapOf(0 to setOf(1))
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(2)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).hasSize(1)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [5, 7, 21])
+    fun `4-clique blowup`(n: Int) {
+        // given
+        val graph = mutableMapOf<Int, MutableSet<Int>>()
+        for (i in 0..<n) {
+            for (j in 0..<n) {
+                if (i % 4 != j % 4)
+                    graph.getOrPut(i) { mutableSetOf() }.add(j)
+            }
+        }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(1, 2, 3)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat((0..<n).filter { !coloring.containsKey(it) }).hasSize(n / 4)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [4, 8, 20])
+    fun `clique with 3 available colors`(n: Int) {
+        // given
+        val graph = mutableMapOf<Int, MutableSet<Int>>()
+        for (i in 0..<n) {
+            for (j in 0..<n) {
+                if (i != j)
+                    graph.getOrPut(i) { mutableSetOf() }.add(j)
+            }
+        }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(1, 2, 3)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat((0..<n).filter { !coloring.containsKey(it) }).hasSize(n - 3)
+    }
+
+    @Test
+    fun `copying chain with one edge`() {
+        // given
+        val graph =
+            mapOf(
+                0 to emptySet(),
+                1 to setOf(3),
+                2 to emptySet(),
+                3 to setOf(1),
+                4 to emptySet(),
+            )
+        val coalesce = (1..4).associateWith { setOf(it - 1) }
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(1, 2)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1, 2, 3, 4)
+        assertThat(coloring[1]).isNotEqualTo(coloring[3])
+        assertThat(coloring[0]).isEqualTo(coloring[2])
+        assertThat(coloring[2]).isEqualTo(coloring[4])
+    }
+
+    @Test
+    fun `copying chain with fixed colors`() {
+        // given
+        val graph = (0..4).associateWith { emptySet<Int>() }
+        val coalesce = (1..4).associateWith { setOf(it - 1) }
+        val fixedColors = mapOf(1 to 9, 3 to 10)
+        val allowedColors = setOf(9, 10)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1, 2, 3, 4)
+        assertThat(coloring[1]).isEqualTo(9)
+        assertThat(coloring[3]).isEqualTo(10)
+        assertThat(setOf(coloring[0], coloring[2], coloring[4])).hasSize(1)
+    }
+
+    @Test
+    fun `bipartite clique`() {
+        // given
+        val graph =
+            (0..<20).associateWith { v ->
+                (0..<20)
+                    .filter { u ->
+                        u / 10 != v / 10
+                    }.toSet()
+            }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrderElementsOf((0..<20))
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [1, 2, 3, 4, 5, 6])
+    fun `half of bipartite clique`(seed: Int) {
+        val n = 20
+        val rnd = Random(seed)
+        val vertices = (0..<n).shuffled(rnd)
+        val graph = vertices.associateWith { mutableSetOf<Int>() }
+        for (i in 0..<n / 2) {
+            for (j in n / 2..<n) {
+                if (rnd.nextBoolean()) {
+                    graph[vertices[i]]!!.add(vertices[j])
+                    graph[vertices[j]]!!.add(vertices[i])
+                }
+            }
+        }
+        val coalesce = mapOf<Int, Set<Int>>()
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrderElementsOf((0..<n))
+    }
+
+    @Test
+    fun `tree of copies`() {
+        val graph =
+            mapOf(
+                1 to setOf(2),
+                2 to setOf(1),
+                3 to setOf(4),
+                4 to setOf(3),
+                5 to setOf(6),
+                6 to setOf(5),
+            )
+        val coalesce =
+            mapOf(
+                1 to setOf(0),
+                2 to setOf(0),
+                3 to setOf(1),
+                4 to setOf(1),
+                5 to setOf(2),
+                6 to setOf(2),
+            )
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6)
+    }
+
+    @Test
+    fun `bipartite clique with some copies`() {
+        // given
+        val vertices = (0..8)
+        val graph = vertices.associateWith { setOf<Int>() }.toMutableMap()
+        val coalesce = vertices.associateWith { mutableSetOf<Int>() }
+
+        val a = (0..2).toSet()
+        val b = (3..5).toSet()
+        a.forEach { graph[it] = b }
+        b.forEach { graph[it] = a }
+        coalesce[6]!!.add(0)
+        coalesce[7]!!.add(5)
+        coalesce[8]!!.add(1)
+
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8)
+        assertThat(coloring[6]).isEqualTo(coloring[0])
+        assertThat(coloring[7]).isEqualTo(coloring[5])
+        assertThat(coloring[8]).isEqualTo(coloring[1])
+    }
+
+    @Test
+    fun `copying with fixed colors`() {
+        // given
+        val graph = (0..3).associateWith { emptySet<Int>() }
+        val coalesce = mapOf(0 to setOf(1), 3 to setOf(2))
+        val fixedColors = mapOf(0 to 2, 2 to 4)
+        val allowedColors = setOf(2, 4)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1, 2, 3)
+    }
+
+    @Test
+    fun `two copies with interference`() {
+        // given
+        val graph = mapOf(1 to setOf(), 2 to setOf(3), 3 to setOf(2))
+        val coalesce = mapOf(1 to setOf(2), 3 to setOf(1))
+        val fixedColors = mapOf<Int, Int>()
+        val allowedColors = setOf(0, 1, 2)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(1, 2, 3)
+        assertThat(coloring[1]).isIn(coloring[2], coloring[3])
+    }
+
+    @Test
+    fun `bipartite clique with some copies and fixed register`() {
+        // given
+        val vertices = (0..8)
+        val graph = vertices.associateWith { setOf<Int>() }.toMutableMap()
+        val a = (0..2).toSet()
+        val b = (3..5).toSet()
+        a.forEach { graph[it] = b }
+        b.forEach { graph[it] = a }
+        val coalesce =
+            mapOf(
+                6 to setOf(0),
+                7 to setOf(5),
+                8 to setOf(1),
+            )
+        val fixedColors = mapOf(0 to 0)
+        val allowedColors = setOf(0, 1, 2)
+
+        // when
+        val coloring =
+            FirstFitGraphColoring<Int, Int>().doColor(
+                graph,
+                coalesce,
+                fixedColors,
+                allowedColors,
+            )
+
+        // then
+        validateColoring(graph, fixedColors, allowedColors, coloring)
+        assertThat(coloring.keys).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8)
+        assertThat(coloring[6]).isEqualTo(coloring[0])
+        assertThat(coloring[7]).isEqualTo(coloring[5])
+        assertThat(coloring[8]).isEqualTo(coloring[1])
+    }
+}

--- a/src/test/kotlin/cacophony/utils/GraphUtilsTest.kt
+++ b/src/test/kotlin/cacophony/utils/GraphUtilsTest.kt
@@ -1,5 +1,9 @@
 package cacophony.utils
 
+import cacophony.graphs.getProperTransitiveClosure
+import cacophony.graphs.getReachableFrom
+import cacophony.graphs.getStronglyConnectedComponents
+import cacophony.graphs.getTransitiveClosure
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
Resolves #207 

## Changes

- extract first fit graph coloring to generic util
- use it in register allocation (and generally it is refactored a bit)
- reuse it in spill handling to color interference graph for spills with "unlimited number of colors" (equal to number of vertices) to reuse the same frame memory for spills with the same color