### PR TITLE
Change registers used for spill handling

### DIFF
--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -262,8 +262,8 @@ class CacophonyPipeline(
 
         val spareRegisters =
             setOf(
-                Register.FixedRegister(HardwareRegister.R8),
-                Register.FixedRegister(HardwareRegister.R9),
+                Register.FixedRegister(HardwareRegister.R10),
+                Register.FixedRegister(HardwareRegister.R11),
             )
 
         logger?.logSpillHandlingAttempt(spareRegisters)


### PR DESCRIPTION
Change registers used for spill handling from R8/R9 to R10/R11.

R8/R9 don't work as they are used for passing arguments to called functions.

R10/R11 seem to be a good fit, as they are not call-preserved and they are not used for passing arguments. Therefore, function call prologues/epilogues should never generate instructions using them.

