### PR TITLE
Add support for combining function calls and field access

### DIFF
--- a/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
+++ b/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
@@ -4,7 +4,7 @@
     "message": {
       "__class__": "UnexpectedToken",
       "tokenName": "INT_LITERAL",
-      "symbolName": "ATOM_LEVEL"
+      "symbolName": "CALL_LEVEL"
     },
     "range": {
       "__class__": "Pair",
@@ -22,7 +22,7 @@
     "__class__": "ReportedError",
     "message": {
       "__class__": "ChildrenEmpty",
-      "symbolName": "LITERAL_LEVEL"
+      "symbolName": "STATEMENT_LEVEL"
     },
     "range": {
       "__class__": "Pair",

--- a/__snapshot__/incorrect/nonexistent_field_access.cac.ast.snap
+++ b/__snapshot__/incorrect/nonexistent_field_access.cac.ast.snap
@@ -46,7 +46,7 @@
               "__class__": "Pair",
               "first": {
                 "__class__": "Location",
-                "value": 8
+                "value": 0
               },
               "second": {
                 "__class__": "Location",

--- a/__snapshot__/incorrect/nonexistent_field_access.cac.errors.snap
+++ b/__snapshot__/incorrect/nonexistent_field_access.cac.errors.snap
@@ -10,7 +10,7 @@
       "__class__": "Pair",
       "first": {
         "__class__": "Location",
-        "value": 8
+        "value": 0
       },
       "second": {
         "__class__": "Location",

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
@@ -295,11 +295,11 @@ class CacophonyGrammar {
                         ),
                     CALL_LEVEL produces
                         (
-                            atomic(LITERAL_LEVEL) or
+                            atomic(LITERAL_LEVEL) concat
                                 (
-                                    atomic(LITERAL_LEVEL) concat
-                                        atomic(FUNCTION_CALL)
-                                )
+                                    atomic(FUNCTION_CALL) or
+                                        (atomic(PERIOD) concat atomic(VARIABLE_IDENTIFIER))
+                                ).star()
 
                         ),
                     LITERAL_LEVEL produces
@@ -311,11 +311,9 @@ class CacophonyGrammar {
                         ),
                     ATOM_LEVEL produces
                         (
-                            (
-                                atomic(VARIABLE_IDENTIFIER) or
-                                    atomic(STRUCT) or
-                                    atomic(BLOCK)
-                            ) concat (atomic(PERIOD) concat atomic(VARIABLE_IDENTIFIER)).star()
+                            atomic(VARIABLE_IDENTIFIER) or
+                                atomic(STRUCT) or
+                                atomic(BLOCK)
                         ),
                     BLOCK produces
                         (

--- a/src/test/kotlin/cacophony/TestAstUtils.kt
+++ b/src/test/kotlin/cacophony/TestAstUtils.kt
@@ -135,7 +135,7 @@ fun variableWrite(variableUse: VariableUse, value: Expression) =
 
 fun block(vararg expressions: Expression) = Block(mockRange(), expressions.toList())
 
-fun call(variableUse: VariableUse, vararg arguments: Expression) = FunctionCall(mockRange(), variableUse, arguments.toList())
+fun call(function: Expression, vararg arguments: Expression) = FunctionCall(mockRange(), function, arguments.toList())
 
 fun call(identifier: String, vararg arguments: Expression) = call(variableUse(identifier), *arguments)
 


### PR DESCRIPTION
`f[].x` should work now (up to CFG generation at least)