### PR TITLE
Syntax for references

### DIFF
--- a/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
+++ b/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
@@ -22,7 +22,7 @@
     "__class__": "ReportedError",
     "message": {
       "__class__": "ChildrenEmpty",
-      "symbolName": "STATEMENT_LEVEL"
+      "symbolName": "REFERENCE_LEVEL"
     },
     "range": {
       "__class__": "Pair",

--- a/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
+++ b/__snapshot__/incorrect/bad_field_access_name.cac.errors.snap
@@ -22,7 +22,7 @@
     "__class__": "ReportedError",
     "message": {
       "__class__": "ChildrenEmpty",
-      "symbolName": "REFERENCE_LEVEL"
+      "symbolName": "ALLOCATION_LEVEL"
     },
     "range": {
       "__class__": "Pair",

--- a/examples/not_yet_correct/references/dereference.cac
+++ b/examples/not_yet_correct/references/dereference.cac
@@ -1,0 +1,5 @@
+let int_reference = $2;
+
+let x: Int = @int_reference;
+
+@int_reference = 5;

--- a/examples/not_yet_correct/references/reference_types.cac
+++ b/examples/not_yet_correct/references/reference_types.cac
@@ -3,4 +3,4 @@ let bool_reference: &Bool = $true;
 
 let struct_reference: &{x: Int, y: Int} = ${x=1, y=2};
 
-#let nested_reference: &&&Int = $$$3;
+let nested_reference: &&&Int = $$$3;

--- a/examples/not_yet_correct/references/reference_types.cac
+++ b/examples/not_yet_correct/references/reference_types.cac
@@ -1,0 +1,6 @@
+let int_reference: &Int = $2;
+let bool_reference: &Bool = $true;
+
+let struct_reference: &{x: Int, y: Int} = ${x=1, y=2};
+
+#let nested_reference: &&&Int = $$$3;

--- a/examples/not_yet_correct/references/reference_variables.cac
+++ b/examples/not_yet_correct/references/reference_variables.cac
@@ -1,0 +1,6 @@
+let int_reference = $2;
+let bool_reference = $true;
+
+let struct_reference = ${x=1, y=2};
+
+let nested_reference = $$$3;

--- a/examples/not_yet_correct/references/refs_with_structs.cac
+++ b/examples/not_yet_correct/references/refs_with_structs.cac
@@ -1,0 +1,14 @@
+let s = {x=1};
+
+let struct_ref: &{x:Int} = $s;
+let int_ref: &Int = $s.x; # field access has higher priority than allocation
+
+let t: {x:Int} = @struct_ref;
+@struct_ref = {x=2};
+
+let x: Int = @struct_ref.x; # dereference has higher priority than field access
+@struct_ref.x = 3;
+
+let s1 = {r=$4};
+let y: Int = @(s1.r);
+@(s1.r)=$5;

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
@@ -298,25 +298,29 @@ class CacophonyGrammar {
                         ),
                     STATEMENT_LEVEL produces
                         (
-                            atomic(REFERENCE_LEVEL) or
+                            atomic(ALLOCATION_LEVEL) or
                                 atomic(RETURN_STATEMENT) or
                                 atomic(WHILE_CLAUSE) or
                                 atomic(IF_CLAUSE)
                         ),
-                    REFERENCE_LEVEL produces
+                    ALLOCATION_LEVEL produces
                         (
                             atomic(CALL_LEVEL) or
-                                (atomic(DOLLAR) concat atomic(REFERENCE_LEVEL)) or
-                                (atomic(AT) concat atomic(REFERENCE_LEVEL))
+                                (atomic(DOLLAR) concat atomic(ALLOCATION_LEVEL))
                         ),
                     CALL_LEVEL produces
                         (
-                            atomic(LITERAL_LEVEL) concat
+                            atomic(DEREFERENCE_LEVEL) concat
                                 (
                                     atomic(FUNCTION_CALL) or
                                         (atomic(PERIOD) concat atomic(VARIABLE_IDENTIFIER))
                                 ).star()
 
+                        ),
+                    DEREFERENCE_LEVEL produces
+                        (
+                            atomic(LITERAL_LEVEL) or
+                                (atomic(AT) concat atomic(DEREFERENCE_LEVEL))
                         ),
                     LITERAL_LEVEL produces
                         (

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
@@ -156,7 +156,10 @@ class CacophonyGrammar {
                         ),
                     TYPE produces
                         (
-                            atomic(TYPE_IDENTIFIER) or atomic(FUNCTION_TYPE) or atomic(STRUCT_TYPE)
+                            atomic(TYPE_IDENTIFIER) or
+                                atomic(FUNCTION_TYPE) or
+                                atomic(STRUCT_TYPE) or
+                                atomic(REFERENCE_TYPE)
                         ),
                     FUNCTION_TYPE produces (
                         (
@@ -194,6 +197,9 @@ class CacophonyGrammar {
                             atomic(LEFT_CURLY_BRACE) concat atomic(RIGHT_CURLY_BRACE)
                         )
 
+                    ),
+                    REFERENCE_TYPE produces (
+                        atomic(AMPERSAND) concat atomic(TYPE)
                     ),
                     ASSIGNMENT_LEVEL produces
                         (
@@ -288,10 +294,16 @@ class CacophonyGrammar {
                         ),
                     STATEMENT_LEVEL produces
                         (
-                            atomic(CALL_LEVEL) or
+                            atomic(REFERENCE_LEVEL) or
                                 atomic(RETURN_STATEMENT) or
                                 atomic(WHILE_CLAUSE) or
                                 atomic(IF_CLAUSE)
+                        ),
+                    REFERENCE_LEVEL produces
+                        (
+                            atomic(CALL_LEVEL) or
+                                (atomic(DOLLAR) concat atomic(REFERENCE_LEVEL)) or
+                                (atomic(AT) concat atomic(REFERENCE_LEVEL))
                         ),
                     CALL_LEVEL produces
                         (

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammar.kt
@@ -228,6 +228,10 @@ class CacophonyGrammar {
                                         atomic(COMPARATOR_LEVEL)
                                 ).star()
                         ),
+                    OPERATOR_LOGICAL_AND produces
+                        (
+                            atomic(AMPERSAND) concat atomic(AMPERSAND)
+                        ),
                     COMPARATOR_LEVEL produces
                         (
                             atomic(EQUALITY_LEVEL) concat

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
@@ -21,6 +21,7 @@ enum class CacophonyGrammarSymbol(
     SEMICOLON(null),
     COMMA(null),
     PERIOD(null),
+    AMPERSAND(null),
 
     // keywords
     KEYWORD_LET(null),
@@ -54,6 +55,8 @@ enum class CacophonyGrammarSymbol(
     OPERATOR_LOGICAL_OR(OperatorBinary.LogicalOr::class),
     OPERATOR_LOGICAL_AND(OperatorBinary.LogicalAnd::class),
     OPERATOR_LOGICAL_NOT(OperatorUnary.Negation::class),
+    AT(Dereference::class),
+    DOLLAR(Allocation::class),
 
     // literals
     INT_LITERAL(Literal.IntLiteral::class),
@@ -79,6 +82,7 @@ enum class CacophonyGrammarSymbol(
     TYPE(Type::class),
     FUNCTION_TYPE(BaseType.Functional::class),
     STRUCT_TYPE(BaseType.Structural::class),
+    REFERENCE_TYPE(BaseType.Referential::class),
     ASSIGNMENT(OperatorBinary::class),
     UNARY(OperatorUnary::class),
 
@@ -89,7 +93,6 @@ enum class CacophonyGrammarSymbol(
     NON_EXISTENT_SYMBOL(null),
 
     // levels
-    STATEMENT_LEVEL(null),
     SEMICOLON_LEVEL(null),
     DECLARATION_LEVEL(null),
     ASSIGNMENT_LEVEL(null),
@@ -99,6 +102,8 @@ enum class CacophonyGrammarSymbol(
     ADDITION_LEVEL(null),
     MULTIPLICATION_LEVEL(null),
     UNARY_LEVEL(null),
+    STATEMENT_LEVEL(null),
+    REFERENCE_LEVEL(null),
     CALL_LEVEL(null),
     LITERAL_LEVEL(null),
     ATOM_LEVEL(null),
@@ -106,6 +111,6 @@ enum class CacophonyGrammarSymbol(
 
     companion object {
         fun fromLexerToken(lexerToken: Token<TokenCategorySpecific>): Token<CacophonyGrammarSymbol> =
-            Token(CacophonyGrammarSymbol.valueOf(lexerToken.category.name), lexerToken.context, lexerToken.rangeFrom, lexerToken.rangeTo)
+            Token(valueOf(lexerToken.category.name), lexerToken.context, lexerToken.rangeFrom, lexerToken.rangeTo)
     }
 }

--- a/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
+++ b/src/main/kotlin/cacophony/parser/CacophonyGrammarSymbol.kt
@@ -103,8 +103,9 @@ enum class CacophonyGrammarSymbol(
     MULTIPLICATION_LEVEL(null),
     UNARY_LEVEL(null),
     STATEMENT_LEVEL(null),
-    REFERENCE_LEVEL(null),
+    ALLOCATION_LEVEL(null),
     CALL_LEVEL(null),
+    DEREFERENCE_LEVEL(null),
     LITERAL_LEVEL(null),
     ATOM_LEVEL(null),
     ;

--- a/src/main/kotlin/cacophony/regex/RegexStrings.kt
+++ b/src/main/kotlin/cacophony/regex/RegexStrings.kt
@@ -65,7 +65,6 @@ object RegexStrings {
             TokenCategorySpecific.OPERATOR_DIVISION_ASSIGNMENT to """/=""",
             TokenCategorySpecific.OPERATOR_MODULO_ASSIGNMENT to """%=""",
             TokenCategorySpecific.OPERATOR_LOGICAL_OR to """\|\|""",
-            TokenCategorySpecific.OPERATOR_LOGICAL_AND to """&&""",
             TokenCategorySpecific.OPERATOR_LOGICAL_NOT to """!""",
             // and the others
             TokenCategorySpecific.INT_LITERAL to """\d(\d)*""",

--- a/src/main/kotlin/cacophony/regex/RegexStrings.kt
+++ b/src/main/kotlin/cacophony/regex/RegexStrings.kt
@@ -33,6 +33,9 @@ object RegexStrings {
             TokenCategorySpecific.SEMICOLON to """;""",
             TokenCategorySpecific.COMMA to """,""",
             TokenCategorySpecific.PERIOD to """.""",
+            TokenCategorySpecific.AMPERSAND to """&""",
+            TokenCategorySpecific.AT to """@""",
+            TokenCategorySpecific.DOLLAR to """$""",
             // keywords
             TokenCategorySpecific.KEYWORD_LET to """let""",
             TokenCategorySpecific.KEYWORD_IF to """if""",
@@ -73,7 +76,7 @@ object RegexStrings {
             TokenCategorySpecific.COMMENT to """#\N*""",
         )
 
-    fun getCategoryRegex(category: TokenCategoryGeneral): String? = generalCategoryMap.get(category)
+    fun getCategoryRegex(category: TokenCategoryGeneral): String? = generalCategoryMap[category]
 
-    fun getCategoryRegex(category: TokenCategorySpecific): String? = specificCategoryMap.get(category)
+    fun getCategoryRegex(category: TokenCategorySpecific): String? = specificCategoryMap[category]
 }

--- a/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
+++ b/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
@@ -66,6 +66,11 @@ private fun constructType(parseTree: ParseTree<CacophonyGrammarSymbol>, diagnost
                     .toMap(),
             )
         }
+        REFERENCE_TYPE -> {
+            require(parseTree is ParseTree.Branch) { "Unable to construct referential type from leaf node $symbol" }
+            val innerType = constructType(parseTree.children.last(), diagnostics)
+            BaseType.Referential(parseTree.range, innerType)
+        }
         else -> throw IllegalStateException("Can't construct type from node $symbol")
     }
 
@@ -98,7 +103,7 @@ fun <T : OperatorBinary> createInstanceBinary(
     return constructor!!.call(range, lhs, rhs)
 }
 
-fun <T : OperatorUnary> createInstanceUnary(kClass: KClass<T>, range: Pair<Location, Location>, subExpression: Expression): Expression {
+fun <T : Expression> createInstanceUnary(kClass: KClass<T>, range: Pair<Location, Location>, subExpression: Expression): Expression {
     val constructor = kClass.primaryConstructor
     return constructor!!.call(range, subExpression)
 }
@@ -329,7 +334,21 @@ private fun generateASTInternal(parseTree: ParseTree<CacophonyGrammarSymbol>, di
                         return OperatorUnary.Minus(range, generateASTInternal(parseTree.children[1], diagnostics))
                     }
                     return createInstanceUnary(
-                        unarySymbol.syntaxTreeClass!! as KClass<OperatorUnary>,
+                        unarySymbol.syntaxTreeClass!! as KClass<out Expression>,
+                        range,
+                        generateASTInternal(parseTree.children[1], diagnostics),
+                    )
+                } else {
+                    throw IllegalArgumentException("Expected the operator symbol, got: $operatorKind")
+                }
+            }
+            REFERENCE_LEVEL -> { // very similar to unary operators
+                assert(childNum == 2)
+                val operatorKind = parseTree.children[0]
+                if (operatorKind is ParseTree.Leaf) {
+                    val unarySymbol = operatorKind.token.category
+                    return createInstanceUnary(
+                        unarySymbol.syntaxTreeClass!! as KClass<out Expression>,
                         range,
                         generateASTInternal(parseTree.children[1], diagnostics),
                     )

--- a/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
+++ b/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
@@ -345,7 +345,7 @@ private fun generateASTInternal(parseTree: ParseTree<CacophonyGrammarSymbol>, di
                     throw IllegalArgumentException("Expected the operator symbol, got: $operatorKind")
                 }
             }
-            REFERENCE_LEVEL -> { // very similar to unary operators
+            DEREFERENCE_LEVEL, ALLOCATION_LEVEL -> { // very similar to unary operators
                 assert(childNum == 2)
                 val operatorKind = parseTree.children[0]
                 if (operatorKind is ParseTree.Leaf) {

--- a/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
+++ b/src/main/kotlin/cacophony/semantic/syntaxtree/ASTGeneration.kt
@@ -133,8 +133,11 @@ private fun operatorRegexToAST(children: List<ParseTree<CacophonyGrammarSymbol>>
         val operatorKind = children[childNum - 2]
         val newChildren = children.subList(0, childNum - 2)
         val range = Pair(first = children[0].range.first, second = children[childNum - 1].range.second)
-        if (operatorKind is ParseTree.Leaf) {
-            val symbol = operatorKind.token.category
+        if (operatorKind is ParseTree.Leaf ||
+            // cheat code to distinguish logical and from double reference
+            (operatorKind is ParseTree.Branch && operatorKind.production.lhs == OPERATOR_LOGICAL_AND)
+        ) {
+            val symbol = getGrammarSymbol(operatorKind)
             return createInstanceBinary(
                 symbol.syntaxTreeClass!! as KClass<OperatorBinary>,
                 range,

--- a/src/main/kotlin/cacophony/semantic/syntaxtree/SyntaxTree.kt
+++ b/src/main/kotlin/cacophony/semantic/syntaxtree/SyntaxTree.kt
@@ -218,13 +218,13 @@ class FunctionCall(
             areEquivalentExpressions(arguments, other.arguments)
 }
 
-class Dereference(range: Pair<Location, Location>, val value: Expression) : BaseExpression(range) {
+class Dereference(range: Pair<Location, Location>, val value: Expression) : BaseExpression(range), Assignable {
     override fun toString() = "deref"
 
     override fun children() = listOf(value)
 
     override fun isEquivalent(other: SyntaxTree?): Boolean =
-        super.isEquivalent(other) &&
+        super<BaseExpression>.isEquivalent(other) &&
             other is Dereference &&
             areEquivalentExpressions(value, other.value)
 }

--- a/src/main/kotlin/cacophony/token/TokenCategorySpecific.kt
+++ b/src/main/kotlin/cacophony/token/TokenCategorySpecific.kt
@@ -14,6 +14,9 @@ enum class TokenCategorySpecific {
     SEMICOLON,
     COMMA,
     PERIOD,
+    AMPERSAND,
+    AT,
+    DOLLAR,
 
     // keywords
     KEYWORD_LET,

--- a/src/test/kotlin/cacophony/semantic/syntaxtree/ASTGenerationTests.kt
+++ b/src/test/kotlin/cacophony/semantic/syntaxtree/ASTGenerationTests.kt
@@ -765,6 +765,34 @@ class ASTGenerationTests {
     }
 
     @Test
+    fun `allocation of struct field`() {
+        val actual = computeAST("\$x.a")
+        val expected =
+            Allocation(
+                anyLocation(),
+                lvalueFieldRef(
+                    variableUse("x"),
+                    "a",
+                ),
+            )
+        assertEquivalentAST(mockWrapInFunction(expected), actual)
+    }
+
+    @Test
+    fun `field of dereference`() {
+        val actual = computeAST("@x.a")
+        val expected =
+            lvalueFieldRef(
+                Dereference(
+                    anyLocation(),
+                    variableUse("x"),
+                ),
+                "a",
+            )
+        assertEquivalentAST(mockWrapInFunction(expected), actual)
+    }
+
+    @Test
     fun `compute basic type`() {
         val actual = computeType("Type")
         val expected =
@@ -797,17 +825,6 @@ class ASTGenerationTests {
                     "x" to BaseType.Basic(anyLocation(), "Type1"),
                     "y" to BaseType.Basic(anyLocation(), "Type2"),
                 ),
-            )
-        assertThat(areEquivalentTypes(expected, actual))
-    }
-
-    @Test
-    fun `compute referential type`() {
-        val actual = computeType("&Type")
-        val expected =
-            BaseType.Referential(
-                anyLocation(),
-                BaseType.Basic(anyLocation(), "Type"),
             )
         assertThat(areEquivalentTypes(expected, actual))
     }


### PR DESCRIPTION
Changes:
-parsing of reference types `&`, allocations `$` and deallocations `@`,
-few simple examples in `not_yet_correct/references`,
-tests for new behavior in `ASTGenerationTest`,
-new kind of tests in the above file checking if type was parsed correctly