### PR TITLE
Implement zeroing for outlines

### DIFF
--- a/libcacophony.c
+++ b/libcacophony.c
@@ -60,9 +60,11 @@ asm(
 
 "test %rdx, %rsi                            \n" //     if(outline.blocks[i / 64] & (1 << (i % 64)))
 "jz .if_end                                 \n" //     {
-"neg %rax                                   \n" //
-"movq $0, 0(%rbp, %rax, 8)                  \n" //         stack[i] = 0
-"neg %rax                                   \n" //
+
+"neg %rax                                   \n" //         # rax is negated because the offsets from rbp are negative
+"movq $0, -8(%rbp, %rax, 8)                 \n" //         stack[i] = 0
+"neg %rax                                   \n" //         # rax is negated back
+
 ".if_end:                                   \n" //     }
 
 "inc %rax                                   \n" //     i++
@@ -98,32 +100,29 @@ void put_mem(long long * ptr, long long val) {
 
 /* ########### Garbage Collection and Allocation ########### */
 
+/*
+ * The memory associated with an allocated object looks as follows:
+ *
+ *      ----- increasing addresses at object site ----->
+ *      [8-byte pointer to outline] [8 bytes of object data] [8 bytes of object data] ...
+ *                |                 ^
+ *                |                 |
+ *                |                 the 8 byte pointer returned from `alloc_object` points here
+ *                |
+ *                V
+ *                [S: 8-byte size of object data] [A: 0th 8-byte block of outline] [B: 1st 8-byte block of outline] ...
+ *                ----- increasing addresses at outline site ----->
+ *
+ * In the outline:
+ * - the size of object data is understood as the number of 8-byte blocks (i.e. Int or reference has size 1).
+ * - A, B, ... are ceil(size / 64) blocks of outline after the size block S - they contain info if a field in the struct
+ *   is a pointer.
+ * Therefore, to check if the i-th field in flattened structure is a pointer, check:
+ *   block number i / 64 on bit position i % 64.
+ */
+
 #ifndef GC_WAIT
 #define GC_WAIT 10
-#endif
-
-#ifndef OUTLINE_PTR_OFFSET_FROM_OBJECT
-#define OUTLINE_PTR_OFFSET_FROM_OBJECT (-1)
-#endif
-
-#ifndef DATA_OFFSET_FROM_OBJECT
-#define DATA_OFFSET_FROM_OBJECT 0
-#endif
-
-#ifndef SIZE_OFFSET_FROM_OUTLINE
-#define SIZE_OFFSET_FROM_OUTLINE 0
-#endif
-
-#ifndef BLOCK_OFFSET_FROM_OUTLINE
-#define BLOCK_OFFSET_FROM_OUTLINE 1
-#endif
-
-#ifndef BLOCK_SIZE_IN_BITS
-#define BLOCK_SIZE_IN_BITS 64
-#endif
-
-#ifndef NULL_REFERENCE
-#define NULL_REFERENCE 0
 #endif
 
 static void run_gc(long long *) {}
@@ -132,19 +131,19 @@ static long long ** alloc_object(long long * outline_ptr) {
     long long size = 8 * (1 + *outline_ptr);
     long long ** allocated_memory_ptr = malloc(size);
     *allocated_memory_ptr = outline_ptr;
-    return allocated_memory_ptr - OUTLINE_PTR_OFFSET_FROM_OBJECT;
+    return allocated_memory_ptr + 1;
 }
 
 static void clean_references(long long ** object_ptr) {
-    long long * outline_ptr = *(object_ptr + OUTLINE_PTR_OFFSET_FROM_OBJECT);
-    long long struct_size = *(outline_ptr + SIZE_OFFSET_FROM_OUTLINE);
-    long long ** fields = object_ptr + DATA_OFFSET_FROM_OBJECT;
-    long long * blocks = outline_ptr + BLOCK_OFFSET_FROM_OUTLINE;
+    long long * outline_ptr = *(object_ptr - 1);
+    long long struct_size = *outline_ptr;
+    long long ** fields = object_ptr;
+    long long * blocks = outline_ptr + 1;
     for(long long i = 0; i < struct_size; i++) {
-        long long field_block = i / BLOCK_SIZE_IN_BITS;
-        long long field_bit = 1LL << (i % BLOCK_SIZE_IN_BITS);
+        long long field_block = i / 64;
+        long long field_bit = 1LL << (i % 64);
         if(blocks[field_block] & field_bit)
-            fields[i] = NULL_REFERENCE;
+            fields[i] = 0;
     }
 }
 

--- a/libcacophony.c
+++ b/libcacophony.c
@@ -28,6 +28,57 @@ asm(
 "jmp check_rsp_impl                         \n"
 );
 
+asm(
+".text                                      \n"
+".p2align 4                                 \n"
+".globl clean_refs                          \n"
+".type  clean_refs, @function               \n"
+
+
+"clean_refs:                                \n"
+
+"push %rax                                  \n" // # preserve registers used as local variables
+"push %rsi                                  \n" //
+"push %rdx                                  \n" //
+"push %rcx                                  \n" //
+
+"xor %rax, %rax                             \n" // i := 0
+
+".loop_begin:                               \n" // while(true) {
+
+"cmp (%rdi), %rax                           \n" //     if(i == outline.struct_size)
+"je .loop_end                               \n" //         break
+
+"mov %rax, %rsi                             \n" //     tmp0 = i
+"shr $6, %rsi                               \n" //     tmp0 = i / 64
+"mov 8(%rdi, %rsi, 8), %rsi                 \n" //     tmp0 = outline.blocks[i / 64]
+
+"mov %rax, %rcx                             \n" //     tmp1 = i
+"and $63, %rcx                              \n" //     tmp1 = i % 64
+"mov $1, %rdx                               \n" //     tmp2 = 1
+"shl %cl, %rdx                              \n" //     tmp2 = 1 << (i % 64)
+
+"test %rdx, %rsi                            \n" //     if(outline.blocks[i / 64] & (1 << (i % 64)))
+"jz .if_end                                 \n" //     {
+"neg %rax                                   \n" //
+"movq $0, 0(%rbp, %rax, 8)                  \n" //         stack[i] = 0
+"neg %rax                                   \n" //
+".if_end:                                   \n" //     }
+
+"inc %rax                                   \n" //     i++
+
+"jmp .loop_begin                            \n" // }
+
+".loop_end:                                 \n" //
+
+"pop %rcx                                   \n" // # restore registers used as local variables as if they never changed
+"pop %rdx                                   \n" //
+"pop %rsi                                   \n" //
+"pop %rax                                   \n" //
+
+"ret                                        \n" // return
+);
+
 void check_rsp_impl(long long rsp) {
     if (rsp % 16 != 8)
         _Exit(50);
@@ -51,13 +102,50 @@ void put_mem(long long * ptr, long long val) {
 #define GC_WAIT 10
 #endif
 
+#ifndef OUTLINE_PTR_OFFSET_FROM_OBJECT
+#define OUTLINE_PTR_OFFSET_FROM_OBJECT (-1)
+#endif
+
+#ifndef DATA_OFFSET_FROM_OBJECT
+#define DATA_OFFSET_FROM_OBJECT 0
+#endif
+
+#ifndef SIZE_OFFSET_FROM_OUTLINE
+#define SIZE_OFFSET_FROM_OUTLINE 0
+#endif
+
+#ifndef BLOCK_OFFSET_FROM_OUTLINE
+#define BLOCK_OFFSET_FROM_OUTLINE 1
+#endif
+
+#ifndef BLOCK_SIZE_IN_BITS
+#define BLOCK_SIZE_IN_BITS 64
+#endif
+
+#ifndef NULL_REFERENCE
+#define NULL_REFERENCE 0
+#endif
+
 static void run_gc(long long *) {}
 
-static long long ** alloc_memory(long long * outline) {
-    long long size = 8 * (1 + *outline);
-    long long **ptr = malloc(size);
-    *ptr = outline;
-    return ptr + 1;
+static long long ** alloc_object(long long * outline_ptr) {
+    long long size = 8 * (1 + *outline_ptr);
+    long long ** allocated_memory_ptr = malloc(size);
+    *allocated_memory_ptr = outline_ptr;
+    return allocated_memory_ptr - OUTLINE_PTR_OFFSET_FROM_OBJECT;
+}
+
+static void clean_references(long long ** object_ptr) {
+    long long * outline_ptr = *(object_ptr + OUTLINE_PTR_OFFSET_FROM_OBJECT);
+    long long struct_size = *(outline_ptr + SIZE_OFFSET_FROM_OUTLINE);
+    long long ** fields = object_ptr + DATA_OFFSET_FROM_OBJECT;
+    long long * blocks = outline_ptr + BLOCK_OFFSET_FROM_OUTLINE;
+    for(long long i = 0; i < struct_size; i++) {
+        long long field_block = i / BLOCK_SIZE_IN_BITS;
+        long long field_bit = 1LL << (i % BLOCK_SIZE_IN_BITS);
+        if(blocks[field_block] & field_bit)
+            fields[i] = NULL_REFERENCE;
+    }
 }
 
 /* ########### Cacophony Built-ins ########### */
@@ -68,5 +156,7 @@ long long ** alloc_struct(long long * outline, long long * rbp) {
         invocation_nr = 0;
         run_gc(rbp);
     }
-    return alloc_memory(outline);
+    long long ** object_ptr = alloc_object(outline);
+    clean_references(object_ptr);
+    return object_ptr;
 }

--- a/libcacophony.c
+++ b/libcacophony.c
@@ -38,9 +38,12 @@ asm(
 "clean_refs:                                \n"
 
 "push %rax                                  \n" // # preserve registers used as local variables
+"push %rdi                                  \n" //
 "push %rsi                                  \n" //
 "push %rdx                                  \n" //
 "push %rcx                                  \n" //
+
+"mov 8(%rbp), %rdi                          \n" // outline := <outline address from stack>
 
 "mov $1, %rax                               \n" // i := 1
 
@@ -76,6 +79,7 @@ asm(
 "pop %rcx                                   \n" // # restore registers used as local variables as if they never changed
 "pop %rdx                                   \n" //
 "pop %rsi                                   \n" //
+"pop %rdi                                   \n" //
 "pop %rax                                   \n" //
 
 "ret                                        \n" // return

--- a/libcacophony.c
+++ b/libcacophony.c
@@ -114,9 +114,9 @@ void put_mem(long long * ptr, long long val) {
  *                ----- increasing addresses at outline site ----->
  *
  * In the outline:
- * - the size of object data is understood as the number of 8-byte blocks (i.e. Int or reference has size 1).
+ * - the size of object data is understood as the number of 8-byte blocks (i.e. Int or reference has size 1)
  * - A, B, ... are ceil(size / 64) blocks of outline after the size block S - they contain info if a field in the struct
- *   is a pointer.
+ *   is a pointer
  * Therefore, to check if the i-th field in flattened structure is a pointer, check:
  *   block number i / 64 on bit position i % 64.
  */

--- a/libcacophony.c
+++ b/libcacophony.c
@@ -42,12 +42,12 @@ asm(
 "push %rdx                                  \n" //
 "push %rcx                                  \n" //
 
-"xor %rax, %rax                             \n" // i := 0
+"mov $1, %rax                               \n" // i := 1
 
 ".loop_begin:                               \n" // while(true) {
 
-"cmp (%rdi), %rax                           \n" //     if(i == outline.struct_size)
-"je .loop_end                               \n" //         break
+"cmp (%rdi), %rax                           \n" //     if(i >= outline.struct_size)
+"jae .loop_end                              \n" //         break
 
 "mov %rax, %rsi                             \n" //     tmp0 = i
 "shr $6, %rsi                               \n" //     tmp0 = i / 64
@@ -62,7 +62,7 @@ asm(
 "jz .if_end                                 \n" //     {
 
 "neg %rax                                   \n" //         # rax is negated because the offsets from rbp are negative
-"movq $0, -8(%rbp, %rax, 8)                 \n" //         stack[i] = 0
+"movq $0, 0(%rbp, %rax, 8)                  \n" //         stack[i] = 0
 "neg %rax                                   \n" //         # rax is negated back
 
 ".if_end:                                   \n" //     }

--- a/src/main/kotlin/cacophony/codegen/BlockLabel.kt
+++ b/src/main/kotlin/cacophony/codegen/BlockLabel.kt
@@ -2,6 +2,12 @@ package cacophony.codegen
 
 import cacophony.semantic.syntaxtree.Definition
 
-data class BlockLabel(val name: String)
+data class BlockLabel(val name: String) {
+    companion object {
+        val cleanReferences = BlockLabel("clean_refs")
+
+        val builtins = listOf(cleanReferences)
+    }
+}
 
 fun functionBodyLabel(function: Definition.FunctionDeclaration): BlockLabel = BlockLabel(function.getLabel())

--- a/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
@@ -24,6 +24,6 @@ fun generateAsmPreamble(foreignFunctions: Set<Definition.ForeignFunctionDeclarat
         listOf("SECTION .data") +
             foreignFunctions.map {
                 "extern ${it.identifier}"
-            } + objectOutlines +
+            } + listOf("extern clean_refs") + objectOutlines + listOf("dummy_outline: dq 0") +
             listOf("global main", "SECTION .text")
     ).joinToString("\n")

--- a/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
@@ -22,8 +22,8 @@ fun generateAsm(func: BlockLabel, blocks: LoweredCFGFragment, registerAllocation
 fun generateAsmPreamble(foreignFunctions: Set<Definition.ForeignFunctionDeclaration>, objectOutlines: List<String>): String =
     (
         listOf("SECTION .data") +
-            foreignFunctions.map {
-                "extern ${it.identifier}"
-            } + listOf("extern clean_refs") + objectOutlines +
+            foreignFunctions.map { "extern ${it.identifier}" } +
+            BlockLabel.builtins.map { "extern ${it.name}" } +
+            objectOutlines +
             listOf("global main", "SECTION .text")
     ).joinToString("\n")

--- a/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/GenerateAsm.kt
@@ -24,6 +24,6 @@ fun generateAsmPreamble(foreignFunctions: Set<Definition.ForeignFunctionDeclarat
         listOf("SECTION .data") +
             foreignFunctions.map {
                 "extern ${it.identifier}"
-            } + listOf("extern clean_refs") + objectOutlines + listOf("dummy_outline: dq 0") +
+            } + listOf("extern clean_refs") + objectOutlines +
             listOf("global main", "SECTION .text")
     ).joinToString("\n")

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -127,8 +127,7 @@ data class Call(val function: Definition.FunctionDeclaration) : InstructionTempl
 
 /**
  * A raw call to a function which does not create a separate stack frame.
- * It can be used for jumping to a reusable piece of code, almost as if it was inlined at the call site, and the returning.
- * One argument can be passed in RDI.
+ * It can be used for jumping to a reusable piece of code, almost as if it was inlined at the call site, and then returning.
  *
  * The destination block must handle the stack just like a function would, e.g. it should assume that at the beginning, the top of the
  * stack holds the return address.
@@ -142,9 +141,8 @@ data class Call(val function: Definition.FunctionDeclaration) : InstructionTempl
 data class RawCall(val label: BlockLabel) : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead: Set<Register> =
         setOf(
-            Register.FixedRegister(HardwareRegister.RDI),
             Register.FixedRegister(HardwareRegister.RSP),
-            Register.FixedRegister(HardwareRegister.RSP),
+            Register.FixedRegister(HardwareRegister.RBP),
         )
 
     override val registersWritten: Set<Register> = emptySet()

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -140,11 +140,12 @@ data class Call(val function: Definition.FunctionDeclaration) : InstructionTempl
  * @param label The label to call
  */
 data class RawCall(val label: BlockLabel) : InstructionTemplates.FixedRegistersInstruction() {
-    override val registersRead: Set<Register> = setOf(
-        Register.FixedRegister(HardwareRegister.RDI),
-        Register.FixedRegister(HardwareRegister.RSP),
-        Register.FixedRegister(HardwareRegister.RSP),
-    )
+    override val registersRead: Set<Register> =
+        setOf(
+            Register.FixedRegister(HardwareRegister.RDI),
+            Register.FixedRegister(HardwareRegister.RSP),
+            Register.FixedRegister(HardwareRegister.RSP),
+        )
 
     override val registersWritten: Set<Register> = emptySet()
 

--- a/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
+++ b/src/main/kotlin/cacophony/codegen/instructions/cacophonyInstructions/ControlflowInstructions.kt
@@ -125,6 +125,19 @@ data class Call(val function: Definition.FunctionDeclaration) : InstructionTempl
     override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping) = "call ${functionBodyLabel(function).name}"
 }
 
+// Call that reads its arguments but preserves all registers
+data class SafeCall(val label: BlockLabel) : InstructionTemplates.FixedRegistersInstruction() {
+    override val registersRead: Set<Register> = setOf(
+        Register.FixedRegister(HardwareRegister.RSP),
+        Register.FixedRegister(HardwareRegister.RBP),
+        Register.FixedRegister(HardwareRegister.RDI),
+    )
+
+    override val registersWritten: Set<Register> = emptySet()
+
+    override fun toAsm(hardwareRegisterMapping: HardwareRegisterMapping): String = "call ${label.name}"
+}
+
 // Utility class to make asm a bit more readable.
 data class Comment(private val comment: String) : InstructionTemplates.FixedRegistersInstruction() {
     override val registersRead: Set<Register> = emptySet()

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
@@ -149,16 +149,11 @@ class InstructionBuilder(val slotFill: SlotFill) {
     }
 
     fun call(label: FunctionLabel) {
-        instructions.add(
-            Call(
-                slotFill.functionFill.getValue(label).function
-                    ?: error("Creating function body label of a pattern node"),
-            ),
-        )
+        instructions.add(Call(slotFill.functionFill.getValue(label).function))
     }
 
-    fun safeCall(label: BlockLabel) {
-        instructions.add(SafeCall(label))
+    fun rawCall(label: BlockLabel) {
+        instructions.add(RawCall(label))
     }
 
     fun comment(comment: String) {

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/InstructionBuilder.kt
@@ -157,6 +157,10 @@ class InstructionBuilder(val slotFill: SlotFill) {
         )
     }
 
+    fun safeCall(label: BlockLabel) {
+        instructions.add(SafeCall(label))
+    }
+
     fun comment(comment: String) {
         instructions.add(Comment(comment))
     }

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -1,6 +1,5 @@
 package cacophony.codegen.patterns.cacophonyPatterns
 
-import cacophony.codegen.BlockLabel
 import cacophony.codegen.instructions.Instruction
 import cacophony.codegen.patterns.NoTemporaryRegistersPattern
 import cacophony.codegen.patterns.SideEffectPattern
@@ -26,11 +25,11 @@ val sideEffectPatterns =
         ModuloAssignmentRegisterPattern,
         ModuloAssignmentMemoryPattern,
         CallPattern,
+        RawCallPattern,
         ReturnPattern,
         PushPattern,
         PushRegPattern,
         PopPattern,
-        CleanReferenceInOutlinePattern,
         // assignments
         RegisterAssignmentPattern,
         RegisterToMemoryWithAddedDisplacementAssignmentPattern,
@@ -211,12 +210,12 @@ object CallPattern : NoTemporaryRegistersPattern {
         }
 }
 
-object CleanReferenceInOutlinePattern : NoTemporaryRegistersPattern {
-    override val tree = CFGNode.CleanReferencesInOutline
+object RawCallPattern : NoTemporaryRegistersPattern {
+    override val tree = CFGNode.NodeSlot(NodeLabel(), CFGNode.RawCall::class)
 
     override fun makeInstance(fill: SlotFill): List<Instruction> =
         instructions(fill) {
-            safeCall(BlockLabel("clean_refs"))
+            rawCall(node(tree).label)
         }
 }
 

--- a/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
+++ b/src/main/kotlin/cacophony/codegen/patterns/cacophonyPatterns/SideEffectPatterns.kt
@@ -1,5 +1,6 @@
 package cacophony.codegen.patterns.cacophonyPatterns
 
+import cacophony.codegen.BlockLabel
 import cacophony.codegen.instructions.Instruction
 import cacophony.codegen.patterns.NoTemporaryRegistersPattern
 import cacophony.codegen.patterns.SideEffectPattern
@@ -29,6 +30,7 @@ val sideEffectPatterns =
         PushPattern,
         PushRegPattern,
         PopPattern,
+        CleanReferenceInOutlinePattern,
         // assignments
         RegisterAssignmentPattern,
         RegisterToMemoryWithAddedDisplacementAssignmentPattern,
@@ -206,6 +208,15 @@ object CallPattern : NoTemporaryRegistersPattern {
     override fun makeInstance(fill: SlotFill) =
         instructions(fill) {
             call(functionLabel)
+        }
+}
+
+object CleanReferenceInOutlinePattern : NoTemporaryRegistersPattern {
+    override val tree = CFGNode.CleanReferencesInOutline
+
+    override fun makeInstance(fill: SlotFill): List<Instruction> =
+        instructions(fill) {
+            safeCall(BlockLabel("clean_refs"))
         }
 }
 

--- a/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
+++ b/src/main/kotlin/cacophony/codegen/registers/SpillHandling.kt
@@ -78,7 +78,7 @@ fun adjustLoweredCFGToHandleSpills(
         instruction is CopyInstruction &&
             spills.contains(instruction.copyInto()) &&
             spills.contains(instruction.copyFrom()) &&
-            spillsColoring[instruction.copyInto()] === spillsColoring[instruction.copyFrom()]
+            spillsColoring[instruction.copyInto()] == spillsColoring[instruction.copyFrom()]
 
     return loweredCfg.map { block ->
         val newInstructions =

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -60,6 +60,10 @@ sealed interface CFGNode {
         override fun children() = listOf(resultSize)
     }
 
+    data object CleanReferencesInOutline : CFGNode {
+        override fun toString(): String = "clean refs"
+    }
+
     // NOTE: Push may be unnecessary since it can be done via Assignment + MemoryAccess
     data class Push(
         val value: CFGNode,

--- a/src/main/kotlin/cacophony/controlflow/CFGNode.kt
+++ b/src/main/kotlin/cacophony/controlflow/CFGNode.kt
@@ -1,5 +1,6 @@
 package cacophony.controlflow
 
+import cacophony.codegen.BlockLabel
 import cacophony.semantic.syntaxtree.Definition
 import kotlin.reflect.KClass
 
@@ -44,12 +45,12 @@ sealed interface CFGNode {
     data class Comment(val comment: String) : Leaf
 
     // declaration is nullable to create pattern without specific function
-    data class Function(override val function: Definition.FunctionDeclaration?) : FunctionRef
+    data class Function(override val function: Definition.FunctionDeclaration) : FunctionRef
 
     data class Call(
         val functionRef: FunctionRef,
     ) : CFGNode {
-        constructor(function: Definition.FunctionDeclaration?) : this(Function(function))
+        constructor(function: Definition.FunctionDeclaration) : this(Function(function))
 
         override fun children(): List<CFGNode> = listOf(functionRef)
 
@@ -60,8 +61,8 @@ sealed interface CFGNode {
         override fun children() = listOf(resultSize)
     }
 
-    data object CleanReferencesInOutline : CFGNode {
-        override fun toString(): String = "clean refs"
+    data class RawCall(val label: BlockLabel) : CFGNode {
+        override fun toString(): String = "raw call ${label.name}"
     }
 
     // NOTE: Push may be unnecessary since it can be done via Assignment + MemoryAccess

--- a/src/main/kotlin/cacophony/controlflow/functions/CallConvention.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/CallConvention.kt
@@ -60,3 +60,5 @@ object SystemVAMD64CallConvention : StackCallConvention(REGISTER_ARGUMENT_ORDER,
 
     override fun preservedRegisters(): List<HardwareRegister> = preservedRegisters
 }
+
+abstract class StacklessCallConvention(private val registerArgumentOrder: List<HardwareRegister>) : CallConvention

--- a/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
@@ -1,5 +1,6 @@
 package cacophony.controlflow.functions
 
+import cacophony.codegen.BlockLabel
 import cacophony.controlflow.*
 import cacophony.controlflow.generation.Layout
 import cacophony.semantic.rtti.getStackFrameLocation
@@ -27,8 +28,8 @@ class PrologueEpilogueHandler(
         nodes.add(registerUse(rsp, false) subeq stackSpace)
 
         nodes.add(pushRegister(rdi, false))
-        nodes.add(registerUse(rdi, false) assign CFGNode.DataLabel("dummy_outline"))
-        nodes.add(CFGNode.CleanReferencesInOutline)
+        nodes.add(registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(REGISTER_SIZE)))
+        nodes.add(CFGNode.RawCall(BlockLabel("clean_refs")))
         nodes.add(popRegister(rdi, false))
 
         // Preserved registers don't hold references

--- a/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
@@ -29,7 +29,7 @@ class PrologueEpilogueHandler(
 
         nodes.add(pushRegister(rdi, false))
         nodes.add(registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(REGISTER_SIZE)))
-        nodes.add(CFGNode.RawCall(BlockLabel("clean_refs")))
+        nodes.add(CFGNode.RawCall(BlockLabel.cleanReferences))
         nodes.add(popRegister(rdi, false))
 
         // Preserved registers don't hold references

--- a/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
@@ -26,6 +26,11 @@ class PrologueEpilogueHandler(
         nodes.add(registerUse(rbp, false) assign registerUse(rsp, false))
         nodes.add(registerUse(rsp, false) subeq stackSpace)
 
+        nodes.add(pushRegister(rdi, false))
+        nodes.add(registerUse(rdi, false) assign CFGNode.DataLabel("dummy_outline"))
+        nodes.add(CFGNode.CleanReferencesInOutline)
+        nodes.add(popRegister(rdi, false))
+
         // Preserved registers don't hold references
         for ((source, destination) in callConvention.preservedRegisters() zip spaceForPreservedRegisters) {
             nodes.add(registerUse(destination, false) assign registerUse(Register.FixedRegister(source), false))

--- a/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
+++ b/src/main/kotlin/cacophony/controlflow/functions/PrologueEpilogueHandler.kt
@@ -27,10 +27,7 @@ class PrologueEpilogueHandler(
         nodes.add(registerUse(rbp, false) assign registerUse(rsp, false))
         nodes.add(registerUse(rsp, false) subeq stackSpace)
 
-        nodes.add(pushRegister(rdi, false))
-        nodes.add(registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(REGISTER_SIZE)))
         nodes.add(CFGNode.RawCall(BlockLabel.cleanReferences))
-        nodes.add(popRegister(rdi, false))
 
         // Preserved registers don't hold references
         for ((source, destination) in callConvention.preservedRegisters() zip spaceForPreservedRegisters) {

--- a/src/main/kotlin/cacophony/controlflow/print/CFGToBuilder.kt
+++ b/src/main/kotlin/cacophony/controlflow/print/CFGToBuilder.kt
@@ -100,4 +100,5 @@ fun cfgNodeToBuilder(tree: CFGNode): String =
         is CFGNode.LogicalNot -> "not(${tree.value})"
         is CFGNode.NotEquals -> "(" + cfgNodeToBuilder(tree.lhs) + " neq " + cfgNodeToBuilder(tree.rhs) + ")"
         is CFGNode.DataLabel -> "CFGNode.DataLabel(${tree.dataLabel})"
+        is CFGNode.CleanReferencesInOutline -> "CFGNode.CleanReferences"
     }

--- a/src/main/kotlin/cacophony/controlflow/print/CFGToBuilder.kt
+++ b/src/main/kotlin/cacophony/controlflow/print/CFGToBuilder.kt
@@ -100,5 +100,5 @@ fun cfgNodeToBuilder(tree: CFGNode): String =
         is CFGNode.LogicalNot -> "not(${tree.value})"
         is CFGNode.NotEquals -> "(" + cfgNodeToBuilder(tree.lhs) + " neq " + cfgNodeToBuilder(tree.rhs) + ")"
         is CFGNode.DataLabel -> "CFGNode.DataLabel(${tree.dataLabel})"
-        is CFGNode.CleanReferencesInOutline -> "CFGNode.CleanReferences"
+        is CFGNode.RawCall -> "raw call(${tree.label})"
     }

--- a/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
@@ -114,6 +114,12 @@ private class FragmentEquivalenceVisitor {
                 assertThat(actual.functionRef).isEqualTo(expected.functionRef)
             }
 
+            is CFGNode.RawCall -> {
+                assertThat(actual).isInstanceOf(CFGNode.RawCall::class.java)
+                check(actual is CFGNode.RawCall)
+                assertThat(actual.label).isEqualTo(expected.label)
+            }
+
             is CFGNode.Comment -> {
                 assertThat(actual).isInstanceOf(CFGNode.Comment::class.java)
                 check(actual is CFGNode.Comment)
@@ -294,8 +300,6 @@ private class FragmentEquivalenceVisitor {
                 assertThat(actual).isInstanceOf(CFGNode.DataLabel::class.java)
                 check(actual is CFGNode.DataLabel)
             }
-
-            is CFGNode.CleanReferencesInOutline -> assertThat(actual).isSameAs(CFGNode.CleanReferencesInOutline)
         }
     }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/CFGEquivalence.kt
@@ -294,6 +294,8 @@ private class FragmentEquivalenceVisitor {
                 assertThat(actual).isInstanceOf(CFGNode.DataLabel::class.java)
                 check(actual is CFGNode.DataLabel)
             }
+
+            is CFGNode.CleanReferencesInOutline -> assertThat(actual).isSameAs(CFGNode.CleanReferencesInOutline)
         }
     }
 

--- a/src/test/kotlin/cacophony/controlflow/generation/FunctionPrologueAndEpilogueTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/FunctionPrologueAndEpilogueTest.kt
@@ -212,9 +212,10 @@ private fun CFGFragmentBuilder.setupStackFrame(localEntry: String, localExit: St
 
 private fun CFGFragmentBuilder.cleanReferences(localEntry: String, localExit: String) {
     localEntry does jump("load outline ptr") { pushRegister(rdi, false) }
-    "load outline ptr" does jump("raw call clean_refs") {
-        registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(8))
-    }
+    "load outline ptr" does
+        jump("raw call clean_refs") {
+            registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(8))
+        }
     "raw call clean_refs" does jump("restore rdi") { CFGNode.RawCall(BlockLabel("clean_refs")) }
     "restore rdi" does jump(localExit) { popRegister(rdi, false) }
 }

--- a/src/test/kotlin/cacophony/controlflow/generation/FunctionPrologueAndEpilogueTest.kt
+++ b/src/test/kotlin/cacophony/controlflow/generation/FunctionPrologueAndEpilogueTest.kt
@@ -23,7 +23,7 @@ class FunctionPrologueAndEpilogueTest {
         val expectedCFG =
             singleFragmentCFG(fDef) {
                 setupStackFrame("entry", "clean references")
-                cleanReferences("clean references", "save preserved")
+                "clean references" does jump("save preserved") { CFGNode.RawCall(BlockLabel("clean_refs")) }
                 savePreservedRegisters("save preserved", "store static link")
                 "store static link" does
                     jump("store result") {
@@ -55,7 +55,7 @@ class FunctionPrologueAndEpilogueTest {
         val expectedCFG =
             singleFragmentCFG(fDef) {
                 setupStackFrame("entry", "clean references")
-                cleanReferences("clean references", "save preserved")
+                "clean references" does jump("save preserved") { CFGNode.RawCall(BlockLabel("clean_refs")) }
                 savePreservedRegisters("save preserved", "store argument")
                 "store argument" does jump("store static link") { writeRegister("0th arg", registerUse(rdi)) }
                 "store static link" does
@@ -100,7 +100,7 @@ class FunctionPrologueAndEpilogueTest {
         val expectedCFG =
             singleFragmentCFG(fDef) {
                 setupStackFrame("entry", "clean references")
-                cleanReferences("clean references", "save preserved")
+                "clean references" does jump("save preserved") { CFGNode.RawCall(BlockLabel("clean_refs")) }
                 savePreservedRegisters("save preserved", "store 0th argument")
                 "store 0th argument" does jump("store 1st argument") { writeRegister("0th arg", registerUse(rdi)) }
                 "store 1st argument" does jump("store 2nd argument") { writeRegister("1st arg", registerUse(rsi)) }
@@ -157,7 +157,7 @@ class FunctionPrologueAndEpilogueTest {
         val expectedFragment =
             standaloneCFGFragment(fDef) {
                 setupStackFrame("entry", "clean references", allocatedSpace = 8)
-                cleanReferences("clean references", "save preserved")
+                "clean references" does jump("save preserved") { CFGNode.RawCall(BlockLabel("clean_refs")) }
                 savePreservedRegisters("save preserved", "store argument")
                 "store argument" does
                     jump("store static link") {
@@ -208,16 +208,6 @@ private fun CFGFragmentBuilder.setupStackFrame(localEntry: String, localExit: St
     "save rbp" does jump("setup rbp") { pushRegister(rbp, false) }
     "setup rbp" does jump("setup rsp") { registerUse(rbp) assign registerUse(rsp) }
     "setup rsp" does jump(localExit) { registerUse(rsp) subeq integer(16 + allocatedSpace) }
-}
-
-private fun CFGFragmentBuilder.cleanReferences(localEntry: String, localExit: String) {
-    localEntry does jump("load outline ptr") { pushRegister(rdi, false) }
-    "load outline ptr" does
-        jump("raw call clean_refs") {
-            registerUse(rdi) assign memoryAccess(registerUse(rbp) add integer(8))
-        }
-    "raw call clean_refs" does jump("restore rdi") { CFGNode.RawCall(BlockLabel("clean_refs")) }
-    "restore rdi" does jump(localExit) { popRegister(rdi, false) }
 }
 
 private fun CFGFragmentBuilder.teardownStackFrame(localEntry: String, localExit: String) {


### PR DESCRIPTION
Implement the functions for clearing object and stack outlines, in C and asm, respectively
Add the call to the label for `clean_refs` with the dedicated `CFGNode.RawCall` in function prologue