### PR TITLE
Fix false positive escaping in function not returning functional type

### DIFF
--- a/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyPipeline.kt
@@ -200,7 +200,7 @@ class CacophonyPipeline(
         val analyzedClosures = analyseClosures()
         val functionHandlers = generateFunctionHandlers(analyzedFunctions, SystemVAMD64CallConvention, variablesMap, analyzedClosures)
         val foreignFunctions = filterForeignFunctions(resolvedNames)
-        val escapeAnalysis = escapeAnalysis(ast, resolvedVariables, analyzedFunctions, variablesMap)
+        val escapeAnalysis = escapeAnalysis(ast, resolvedVariables, analyzedFunctions, variablesMap, types)
         return AstAnalysisResult(
             resolvedVariables,
             types,

--- a/src/main/kotlin/cacophony/semantic/analysis/EscapeAnalysis.kt
+++ b/src/main/kotlin/cacophony/semantic/analysis/EscapeAnalysis.kt
@@ -19,7 +19,7 @@ fun escapeAnalysis(
     resolvedVariables: ResolvedVariables,
     functionAnalysis: FunctionAnalysisResult,
     variablesMap: VariablesMap,
-    types: TypeCheckingResult
+    types: TypeCheckingResult,
 ): EscapeAnalysisResult {
     val baseVisitor = BaseEscapeAnalysisVisitor(resolvedVariables, variablesMap, types)
     baseVisitor.visit(ast)
@@ -101,7 +101,7 @@ private data class BaseEscapeAnalysisResult(
 private class BaseEscapeAnalysisVisitor(
     val resolvedVariables: ResolvedVariables,
     val variablesMap: VariablesMap,
-    val types: TypeCheckingResult
+    val types: TypeCheckingResult,
 ) {
     private var currentStaticDepth = -1
     private var functionTypeStack = ArrayDeque<FunctionType>()

--- a/src/main/kotlin/cacophony/semantic/analysis/EscapeAnalysis.kt
+++ b/src/main/kotlin/cacophony/semantic/analysis/EscapeAnalysis.kt
@@ -4,17 +4,24 @@ import cacophony.controlflow.Variable
 import cacophony.semantic.names.ResolvedVariables
 import cacophony.semantic.syntaxtree.*
 import cacophony.semantic.syntaxtree.Definition.FunctionDefinition
+import cacophony.semantic.types.FunctionType
+import cacophony.semantic.types.StructType
+import cacophony.semantic.types.TypeCheckingResult
+import cacophony.semantic.types.TypeExpr
 import kotlin.math.min
 
 typealias EscapeAnalysisResult = Set<Variable>
+
+class EscapeAnalysisException(reason: String) : Exception(reason)
 
 fun escapeAnalysis(
     ast: AST,
     resolvedVariables: ResolvedVariables,
     functionAnalysis: FunctionAnalysisResult,
     variablesMap: VariablesMap,
+    types: TypeCheckingResult
 ): EscapeAnalysisResult {
-    val baseVisitor = BaseEscapeAnalysisVisitor(resolvedVariables, variablesMap)
+    val baseVisitor = BaseEscapeAnalysisVisitor(resolvedVariables, variablesMap, types)
     baseVisitor.visit(ast)
     val baseResult = baseVisitor.getResult()
 
@@ -94,8 +101,10 @@ private data class BaseEscapeAnalysisResult(
 private class BaseEscapeAnalysisVisitor(
     val resolvedVariables: ResolvedVariables,
     val variablesMap: VariablesMap,
+    val types: TypeCheckingResult
 ) {
     private var currentStaticDepth = -1
+    private var functionTypeStack = ArrayDeque<FunctionType>()
     private val assignmentLhsStack = ArrayDeque<MutableSet<Variable>>()
     private val assignmentRhsStack = ArrayDeque<MutableSet<Variable>>()
     private val returnStack = ArrayDeque<MutableSet<Variable>>()
@@ -118,7 +127,7 @@ private class BaseEscapeAnalysisVisitor(
             is FieldRef.LValue -> visitExpression(expr.obj)
             is FieldRef.RValue -> visitExpression(expr.obj)
             is Definition.VariableDeclaration -> visitVariableDeclaration(expr)
-            is LambdaExpression -> visitFunctionBody(expr.body)
+            is LambdaExpression -> visitLambdaExpression(expr)
             is FunctionDefinition -> visitFunctionDeclaration(expr)
             is FunctionCall -> {
                 visitExpression(expr.function)
@@ -163,8 +172,9 @@ private class BaseEscapeAnalysisVisitor(
         }
     }
 
-    private fun visitFunctionBody(expr: Expression) {
+    private fun visitFunctionBody(expr: Expression, functionType: FunctionType) {
         currentStaticDepth += 1
+        functionTypeStack.add(functionType)
 
         val lastBodyExpression = if (expr is Block) expr.expressions.lastOrNull() else expr
 
@@ -174,13 +184,36 @@ private class BaseEscapeAnalysisVisitor(
 
         if (lastBodyExpression != null) visitReturnedExpression(lastBodyExpression)
 
+        functionTypeStack.removeLast()
         currentStaticDepth -= 1
     }
 
     private fun visitFunctionDeclaration(expr: Definition.FunctionDeclaration) {
         when (expr) {
             is Definition.ForeignFunctionDeclaration -> return
-            is FunctionDefinition -> visitFunctionBody(expr.body)
+            is FunctionDefinition -> {
+                val functionType = types.definitionTypes[expr]
+                if (functionType == null || functionType !is FunctionType) {
+                    throw EscapeAnalysisException("Unexpected type $functionType of function $expr")
+                }
+                visitFunctionBody(expr.body, types.definitionTypes[expr] as FunctionType)
+            }
+        }
+    }
+
+    private fun visitLambdaExpression(expr: LambdaExpression) {
+        val lambdaType = types.expressionTypes[expr]
+        if (lambdaType == null || lambdaType !is FunctionType) {
+            throw EscapeAnalysisException("Unexpected type $lambdaType of lambda expression $expr")
+        }
+        visitFunctionBody(expr.body, types.expressionTypes[expr] as FunctionType)
+    }
+
+    private fun canEscapeViaReturn(returnType: TypeExpr?): Boolean {
+        return when (returnType) {
+            is FunctionType -> true
+            is StructType -> returnType.fields.values.any { canEscapeViaReturn(it) }
+            else -> false
         }
     }
 
@@ -188,7 +221,7 @@ private class BaseEscapeAnalysisVisitor(
         returnStack.add(mutableSetOf())
         visitExpression(expr)
 
-        if (returnStack.last().isNotEmpty()) {
+        if (returnStack.last().isNotEmpty() && canEscapeViaReturn(functionTypeStack.last().result)) {
             returnVariables.getOrPut(currentStaticDepth) { mutableSetOf() }.addAll(returnStack.last())
         }
 

--- a/src/test/kotlin/cacophony/semantic/analysis/EscapeAnalysisKtTest.kt
+++ b/src/test/kotlin/cacophony/semantic/analysis/EscapeAnalysisKtTest.kt
@@ -32,13 +32,14 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, gDef, gUse))
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
-                gDef to FunctionType(listOf(), BuiltinType.IntegerType)
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
+                    gDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables =
             mapOf(
@@ -103,13 +104,14 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, gDef, hDef, hUse))
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
-                gDef to FunctionType(listOf(), BuiltinType.IntegerType)
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
+                    gDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables =
             mapOf(
@@ -175,13 +177,18 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, gDef, sDef, sUse))
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                fDef to FunctionType(listOf(), FunctionType(listOf(), StructType(mapOf("h" to FunctionType(listOf(), BuiltinType.IntegerType))))),
-                gDef to FunctionType(listOf(), BuiltinType.IntegerType)
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    fDef to
+                        FunctionType(
+                            listOf(),
+                            FunctionType(listOf(), StructType(mapOf("h" to FunctionType(listOf(), BuiltinType.IntegerType)))),
+                        ),
+                    gDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables =
             mapOf(
@@ -247,14 +254,15 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, gDef, hUse assign gUse))
         val ast = block(hDef, fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                hDef to FunctionType(listOf(), BuiltinType.IntegerType),
-                fDef to FunctionType(listOf(), BuiltinType.UnitType),
-                gDef to FunctionType(listOf(), BuiltinType.IntegerType)
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    hDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                    fDef to FunctionType(listOf(), BuiltinType.UnitType),
+                    gDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables =
             mapOf(
@@ -317,14 +325,15 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, lambda))
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(
-                lambda to FunctionType(listOf(), BuiltinType.IntegerType),
-            ),
-            mapOf(
-                fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
+        val types =
+            TypeCheckingResult(
+                mapOf(
+                    lambda to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
+                mapOf(
+                    fDef to FunctionType(listOf(), FunctionType(listOf(), BuiltinType.IntegerType)),
+                ),
             )
-        )
 
         val resolvedVariables =
             mapOf(
@@ -360,7 +369,7 @@ class EscapeAnalysisKtTest {
         // then
         assertThat(result).containsExactlyInAnyOrder(xVar)
     }
-    
+
     /*
      * let f = [x: Int] -> Int => x;
      * EXPECTED: {} escape
@@ -373,12 +382,13 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(xDef), xUse)
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                fDef to FunctionType(listOf(BuiltinType.IntegerType), BuiltinType.IntegerType),
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    fDef to FunctionType(listOf(BuiltinType.IntegerType), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables = mapOf(xUse to xDef)
 
@@ -418,12 +428,13 @@ class EscapeAnalysisKtTest {
         val fDef = functionDefinition("f", listOf(), block(xDef, xUse))
         val ast = block(fDef)
 
-        val types = TypeCheckingResult(
-            mapOf(),
-            mapOf(
-                fDef to FunctionType(listOf(), BuiltinType.IntegerType),
+        val types =
+            TypeCheckingResult(
+                mapOf(),
+                mapOf(
+                    fDef to FunctionType(listOf(), BuiltinType.IntegerType),
+                ),
             )
-        )
 
         val resolvedVariables = mapOf(xUse to xDef)
 


### PR DESCRIPTION
Fixes an issue where return values are marked as escaping unnecessarily