### PR TITLE
Dont mark escaping variables via assignments to non-functional types

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -23,6 +23,7 @@ class Main : CliktCommand() {
     private val logNameRes by option("--log-names").flag()
     private val logOverloads by option("--log-overloads").flag()
     private val logTypes by option("--log-types").flag()
+    private val logEscapeAnalysis by option("--log-escape-analysis").flag()
     private val logVariables by option("--log-variables").flag()
     private val logCallGraph by option("--log-callgraph").flag()
     private val logFunctions by option("--log-functions").flag()
@@ -58,6 +59,7 @@ class Main : CliktCommand() {
                 verbose || logAnalysis || logNameRes,
                 verbose || logAnalysis || logOverloads,
                 verbose || logAnalysis || logTypes,
+                verbose || logAnalysis || logEscapeAnalysis,
                 verbose || logAnalysis || logVariables,
                 verbose || logAnalysis || logCallGraph,
                 verbose || logAnalysis || logFunctions,

--- a/src/main/kotlin/cacophony/pipeline/CacophonyLogger.kt
+++ b/src/main/kotlin/cacophony/pipeline/CacophonyLogger.kt
@@ -10,10 +10,7 @@ import cacophony.controlflow.print.programCfgToGraphviz
 import cacophony.grammars.AnalyzedGrammar
 import cacophony.grammars.ParseTree
 import cacophony.parser.CacophonyGrammarSymbol
-import cacophony.semantic.analysis.CallGraph
-import cacophony.semantic.analysis.FunctionAnalysisResult
-import cacophony.semantic.analysis.VariableUseType
-import cacophony.semantic.analysis.VariablesMap
+import cacophony.semantic.analysis.*
 import cacophony.semantic.names.NameResolutionResult
 import cacophony.semantic.names.ResolvedName
 import cacophony.semantic.names.ResolvedVariables
@@ -32,6 +29,7 @@ class CacophonyLogger(
     private val logNameRes: Boolean,
     private val logOverloads: Boolean,
     private val logTypes: Boolean,
+    private val logEscapeAnalysis: Boolean,
     private val logVariables: Boolean,
     private val logCallGraph: Boolean,
     private val logFunctions: Boolean,
@@ -124,6 +122,19 @@ class CacophonyLogger(
     }
 
     override fun logFailedTypeChecking() = printError("Type checking failed :(")
+
+    override fun logSuccessfulEscapeAnalysis(result: EscapeAnalysisResult, variableMap: VariablesMap) {
+        if (logEscapeAnalysis) {
+            val variableToDefinition = variableMap.definitions.entries.associate { (k, v) -> v to k }
+            logMaybeSave(
+                "Escaping variables",
+                result
+                    .joinToString("\n") { "$it (${variableToDefinition.getOrDefault(it, "no declaration")})" },
+            )
+        }
+    }
+
+    override fun logFailedEscapeAnalysis() = printError("Escape analysis failed :(")
 
     override fun logSuccessfulVariableCreation(variableMap: VariablesMap) {
         if (logVariables) {

--- a/src/main/kotlin/cacophony/pipeline/Logger.kt
+++ b/src/main/kotlin/cacophony/pipeline/Logger.kt
@@ -46,6 +46,10 @@ interface Logger {
 
     fun logFailedTypeChecking()
 
+    fun logFailedEscapeAnalysis()
+
+    fun logSuccessfulEscapeAnalysis(result: EscapeAnalysisResult, variableMap: VariablesMap)
+
     fun logSuccessfulCallGraphGeneration(callGraph: CallGraph)
 
     fun logFailedCallGraphGeneration()


### PR DESCRIPTION
## Changes

- don't mark escaping variables via assignments to non-functional types
- add `--log-escape-analysis` flag to compiler and appropriate functions to logger